### PR TITLE
Replace timeline with new scroll animation

### DIFF
--- a/static/css/emergency-system.css
+++ b/static/css/emergency-system.css
@@ -666,3 +666,21 @@
 #intro-overlay{position:fixed;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;background:#000;z-index:10000;font-family:'Signika Negative',sans-serif;text-align:center}
 #intro-subtitle{margin-top:.5rem;font-size:1.25rem;color:#ccc}
 
+/* SVG Timeline Animation */
+#svg-stage {
+    max-width: 600px;
+    overflow: visible;
+    margin: 4rem auto 0;
+}
+
+#svg-stage .theLine {
+    fill: none;
+    stroke: #ffffff;
+    stroke-width: 10px;
+}
+
+#svg-stage .ball {
+    fill: #ffffff;
+    visibility: hidden;
+}
+

--- a/static/css/emergency-system.css
+++ b/static/css/emergency-system.css
@@ -670,7 +670,7 @@
 #svg-stage {
     max-width: 600px;
     overflow: visible;
-    margin: 4rem auto 0;
+    margin: 60vh auto 0;
 }
 
 #svg-stage .theLine {

--- a/static/css/emergency-system.css
+++ b/static/css/emergency-system.css
@@ -684,3 +684,15 @@
     visibility: hidden;
 }
 
+#svg-stage .line {
+    fill: none;
+    stroke: #ffffff;
+    stroke-width: 2px;
+}
+
+#svg-stage text {
+    fill: #ffffff;
+    font-size: 15px;
+    visibility: hidden;
+}
+

--- a/static/js/emergency-system.js
+++ b/static/js/emergency-system.js
@@ -317,9 +317,9 @@ function initTimelineAnimation() {
             ease: 'elastic(2.5, 1)'
         }
     })
-    .to('.ball02', {}, 0.2)
-    .to('.ball03', {}, 0.33)
-    .to('.ball04', {}, 0.46);
+    .to('.ball02, .text01', {}, 0.2)
+    .to('.ball03, .text02', {}, 0.33)
+    .to('.ball04, .text03', {}, 0.46);
 
     gsap.timeline({
         defaults: { duration: 1 },

--- a/static/js/emergency-system.js
+++ b/static/js/emergency-system.js
@@ -1,7 +1,7 @@
 // static/js/emergency-system.js
 
 // Register GSAP Plugins
-gsap.registerPlugin(ScrollTrigger);
+gsap.registerPlugin(ScrollTrigger, DrawSVGPlugin, MotionPathPlugin);
 
 // Initialize animations when DOM is loaded
 document.addEventListener('DOMContentLoaded', () => {
@@ -306,7 +306,6 @@ function initScrollAnimations() {
 
 // SVG Timeline Animation
 function initTimelineAnimation() {
-    gsap.registerPlugin(ScrollTrigger, DrawSVGPlugin, MotionPathPlugin);
     gsap.defaults({ ease: 'none' });
 
     const pulses = gsap.timeline({

--- a/static/js/emergency-system.js
+++ b/static/js/emergency-system.js
@@ -304,36 +304,43 @@ function initScrollAnimations() {
     });
 }
 
-// Timeline Animation
+// SVG Timeline Animation
 function initTimelineAnimation() {
-    const steps = gsap.utils.toArray('.timeline-step');
-    
-    steps.forEach((step, index) => {
-        gsap.to(step, {
-            scrollTrigger: {
-                trigger: step,
-                start: 'top 80%',
-                toggleActions: 'play none none reverse'
-            },
-            opacity: 1,
-            x: 0,
-            duration: 0.8,
-            delay: index * 0.2,
-            ease: "power3.out"
-        });
-    });
-    
-    // Animate timeline line progress
-    gsap.to('.timeline-line', {
+    gsap.registerPlugin(ScrollTrigger, DrawSVGPlugin, MotionPathPlugin);
+    gsap.defaults({ ease: 'none' });
+
+    const pulses = gsap.timeline({
+        defaults: {
+            duration: 0.05,
+            autoAlpha: 1,
+            scale: 2,
+            transformOrigin: 'center',
+            ease: 'elastic(2.5, 1)'
+        }
+    })
+    .to('.ball02', {}, 0.2)
+    .to('.ball03', {}, 0.33)
+    .to('.ball04', {}, 0.46);
+
+    gsap.timeline({
+        defaults: { duration: 1 },
         scrollTrigger: {
-            trigger: '.timeline-container',
-            start: 'top 60%',
-            end: 'bottom 40%',
-            scrub: 1
-        },
-        background: 'linear-gradient(to bottom, #dc2626 0%, #dc2626 100%)',
-        ease: "none"
-    });
+            trigger: '#svg-stage',
+            scrub: true,
+            start: 'top center',
+            end: 'bottom center'
+        }
+    })
+    .to('.ball01', { duration: 0.01, autoAlpha: 1 })
+    .from('.theLine', { drawSVG: 0 }, 0)
+    .to('.ball01', {
+        motionPath: {
+            path: '.theLine',
+            align: '.theLine',
+            alignOrigin: [0.5, 0.5]
+        }
+    }, 0)
+    .add(pulses, 0);
 }
 
 // Network Animation

--- a/templates/index.html
+++ b/templates/index.html
@@ -432,11 +432,23 @@
         
         <div class="flex justify-center">
             <svg id="svg-stage" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 1200">
-                <path class="theLine" d="M -5,0
-                   Q 450 230 300 450
-                   T 130 750
-                   Q 100 850 300 1000
-                   T 150 1200" />
+                <path class="line01 line" d="M 10 200 600 200"></path>
+                <path class="line02 line" d="M 10 400 600 400"></path>
+                <path class="line03 line" d="M 10 600 600 600"></path>
+                <path class="line04 line" d="M 10 800 600 800"></path>
+                <path class="line05 line" d="M 10 1000 600 1000"></path>
+                <text class="text01" x="30" y="190">2018</text>
+                <text class="text02" x="30" y="390">2019</text>
+                <text class="text03" x="30" y="590">2020</text>
+
+                <path class="theLine"
+                      d="M -5,0
+                         Q 450 230 300 450 
+                         T 130 750
+                         Q 100 850 300 1000
+                         T 150 1200"
+                      fill="none" stroke="white" stroke-width="10px" />
+
                 <circle class="ball ball01" r="20" cx="50" cy="100"></circle>
                 <circle class="ball ball02" r="20" cx="278" cy="201"></circle>
                 <circle class="ball ball03" r="20" cx="327" cy="401"></circle>

--- a/templates/index.html
+++ b/templates/index.html
@@ -586,8 +586,8 @@
 {% block extra_js %}
 <script src="https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/gsap.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/ScrollTrigger.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/DrawSVGPlugin.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/MotionPathPlugin.min.js"></script>
+<script src="https://assets.codepen.io/16327/DrawSVGPlugin.min.js"></script>
+<script src="https://assets.codepen.io/16327/MotionPathPlugin.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/pixi.js/7.2.4/browser/pixi.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/ExpoScaleEase.min.js"></script>
 <script src="{{ url_for('static', filename='js/emergency-system.js') }}"></script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -430,52 +430,18 @@
             </h2>
         </div>
         
-        <div class="timeline-container max-w-4xl mx-auto">
-            <div class="timeline-line"></div>
-            
-            <!-- Step 1 -->
-            <div class="timeline-step" data-step="1">
-                <div class="timeline-content">
-                    <div class="timeline-icon bg-red-500">
-                        <i class="fas fa-hand-pointer"></i>
-                    </div>
-                    <h3 class="text-xl font-semibold mb-2">Activación de Emergencia</h3>
-                    <p class="text-gray-600">Se presiona el botón correspondiente en la botonera</p>
-                </div>
-            </div>
-            
-            <!-- Step 2 -->
-            <div class="timeline-step" data-step="2">
-                <div class="timeline-content">
-                    <div class="timeline-icon bg-blue-500">
-                        <i class="fas fa-wifi"></i>
-                    </div>
-                    <h3 class="text-xl font-semibold mb-2">Mensaje MQTT</h3>
-                    <p class="text-gray-600">Se envía la alerta al broker en la nube</p>
-                </div>
-            </div>
-            
-            <!-- Step 3 -->
-            <div class="timeline-step" data-step="3">
-                <div class="timeline-content">
-                    <div class="timeline-icon bg-purple-500">
-                        <i class="fas fa-microchip"></i>
-                    </div>
-                    <h3 class="text-xl font-semibold mb-2">Procesamiento Central</h3>
-                    <p class="text-gray-600">Software analiza y distribuye la alerta</p>
-                </div>
-            </div>
-            
-            <!-- Step 4 -->
-            <div class="timeline-step" data-step="4">
-                <div class="timeline-content">
-                    <div class="timeline-icon bg-green-500">
-                        <i class="fas fa-check-circle"></i>
-                    </div>
-                    <h3 class="text-xl font-semibold mb-2">Activación de Dispositivos</h3>
-                    <p class="text-gray-600">Semáforos y displays muestran la información</p>
-                </div>
-            </div>
+        <div class="flex justify-center">
+            <svg id="svg-stage" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 1200">
+                <path class="theLine" d="M -5,0
+                   Q 450 230 300 450
+                   T 130 750
+                   Q 100 850 300 1000
+                   T 150 1200" />
+                <circle class="ball ball01" r="20" cx="50" cy="100"></circle>
+                <circle class="ball ball02" r="20" cx="278" cy="201"></circle>
+                <circle class="ball ball03" r="20" cx="327" cy="401"></circle>
+                <circle class="ball ball04" r="20" cx="203" cy="601"></circle>
+            </svg>
         </div>
     </div>
 </section>
@@ -620,6 +586,8 @@
 {% block extra_js %}
 <script src="https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/gsap.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/ScrollTrigger.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/DrawSVGPlugin.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/MotionPathPlugin.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/pixi.js/7.2.4/browser/pixi.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/ExpoScaleEase.min.js"></script>
 <script src="{{ url_for('static', filename='js/emergency-system.js') }}"></script>


### PR DESCRIPTION
## Summary
- swap out the old "Cómo Funciona" timeline markup for SVG timeline
- load GSAP DrawSVG and MotionPath plugins
- implement new animation logic in `emergency-system.js`
- style the SVG timeline

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684265f46468833292ddce207248c08e