### PR TITLE
Add initial presentation overlay

### DIFF
--- a/static/css/gsap_css/clamp.css
+++ b/static/css/gsap_css/clamp.css
@@ -121,10 +121,3 @@ transform: rotate(0.1deg);
 .logo svg {
   opacity: 0
 }
-.gsap-infobar,
-a,
-nav,
-header,
-footer {
-  display: none !important;
-}

--- a/static/css/presentation.css
+++ b/static/css/presentation.css
@@ -1,0 +1,21 @@
+#presentation.presentation-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 10000;
+    background: #000;
+    overflow: hidden;
+}
+
+#presentation.fade-out {
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 1s ease;
+}
+
+body.no-scroll {
+    overflow: hidden;
+}
+

--- a/static/js/presentation.js
+++ b/static/js/presentation.js
@@ -1,0 +1,21 @@
+// Script to display clamp animation overlay before showing the page
+// The overlay fades out after a short delay
+
+document.addEventListener('DOMContentLoaded', () => {
+    const presentation = document.getElementById('presentation');
+    if (!presentation) return;
+
+    document.body.classList.add('no-scroll');
+
+    const hidePresentation = () => {
+        presentation.classList.add('fade-out');
+        setTimeout(() => {
+            presentation.style.display = 'none';
+            document.body.classList.remove('no-scroll');
+        }, 1000); // match fade-out transition
+    };
+
+    // Adjust timeout to match clamp animation duration
+    setTimeout(hidePresentation, 6000);
+});
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,10 +5,11 @@
 {% block extra_css %}
 <link href="{{ url_for('static', filename='css/emergency-system.css') }}" rel="stylesheet">
 <link href="{{ url_for('static', filename='css/confetti.css') }}" rel="stylesheet">
+<link href="{{ url_for('static', filename='css/presentation.css') }}" rel="stylesheet">
 {% endblock %}
 
 {% block content %}
-<div class="presentation">
+<div id="presentation" class="presentation-overlay">
 
 {% include 'GSAP_Templates/clamp.html' %}
 
@@ -582,4 +583,5 @@
 <script src="https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/ExpoScaleEase.min.js"></script>
 <script src="{{ url_for('static', filename='js/emergency-system.js') }}"></script>
 <script src="{{ url_for('static', filename='js/confetti.js') }}"></script>
+<script src="{{ url_for('static', filename='js/presentation.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add overlay CSS and JS to show clamp animation before page content
- load new overlay styles/scripts in index
- remove global element hiding in clamp.css

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f64cadf8833295895ae15eb34a1c