### PR TITLE
Implement global GSAP initialization

### DIFF
--- a/static/js/confetti.js
+++ b/static/js/confetti.js
@@ -1,7 +1,7 @@
 // Confetti cannon effect using GSAP
 // Adapted from example snippet
 
-gsap.registerPlugin(Observer, CustomEase, CustomWiggle, Physics2DPlugin, ScrollTrigger);
+// Plugins registrados globalmente en gsap_main.js
 
 class confettiCannon {
   constructor(el) {

--- a/static/js/emergency-system.js
+++ b/static/js/emergency-system.js
@@ -1,7 +1,6 @@
 // static/js/emergency-system.js
 
-// Register GSAP Plugins
-gsap.registerPlugin(ScrollTrigger);
+// Plugins registrados globalmente en gsap_main.js
 
 // Initialize animations when DOM is loaded
 document.addEventListener('DOMContentLoaded', () => {

--- a/static/js/gsap_js/clamp.js
+++ b/static/js/gsap_js/clamp.js
@@ -1,44 +1,18 @@
-gsap.registerPlugin(ScrollTrigger, ScrollSmoother);
+export function initClampModule(gsap, smoother){
+  smoother = smoother || window.gsapApp.getSmoother();
+  gsap.from('.draw', {
+    drawSVG: "0%",
+    ease: "expo.out",
+    scrollTrigger: {
+      trigger: '.heading',
+      start: "clamp(top center)",
+      scrub: true,
+      pin: '.pin',
+      pinSpacing: false,
+      markers:false,
+    }
+  });
 
-let smoother = ScrollSmoother.create({
-  smooth: 2, 
-  effects: true
-});
-
-gsap.from('.draw', {
-  drawSVG: "0%",
-  ease: "expo.out",
-  scrollTrigger: {
-    trigger: '.heading',
-    start: "clamp(top center)",
-    scrub: true,
-    pin: '.pin',
-    pinSpacing: false,
-    markers:false,
-  }
-})
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-// little setup - ignore
-gsap.set(".logo svg", {opacity: 1})
-
-
-// 💚 This just adds the GSAP link to this pen, don't copy this bit
-import { GSAPInfoBar } from "https://codepen.io/GreenSock/pen/vYqpyLg.js"
-new GSAPInfoBar({ link: "https://gsap.com/docs/v3/Plugins/ScrollSmoother/"});
-// 💚 Happy tweening!
+  // little setup - ignore
+  gsap.set('.logo svg', {opacity: 1});
+}

--- a/static/js/gsap_js/funcion.js
+++ b/static/js/gsap_js/funcion.js
@@ -1,43 +1,33 @@
-console.clear();
+export function initFuncionModule(gsap){
+  gsap.defaults({ease: 'none'});
 
-gsap.registerPlugin(ScrollTrigger, DrawSVGPlugin, MotionPathPlugin);
-gsap.defaults({ease: "none"});
+  const pulses = gsap.timeline({
+    defaults: {
+      duration: 0.05,
+      autoAlpha: 1,
+      scale: 2,
+      transformOrigin: 'center',
+      ease: 'elastic(2.5, 1)'
+    }
+  })
+  .to('.ball02, .text01', {}, 0.2)
+  .to('.ball03, .text02', {}, 0.33)
+  .to('.ball04, .text03', {}, 0.46);
 
-
-
-const pulses = gsap.timeline({
-  defaults: {
-    duration: 0.05, 
-    autoAlpha: 1, 
-    scale: 2, 
-    transformOrigin: 'center', 
-    ease: "elastic(2.5, 1)"
-  }})
-.to(".ball02, .text01", {}, 0.2) 
-.to(".ball03, .text02", {}, 0.33)
-.to(".ball04, .text03", {}, 0.46)
-
-const main = gsap.timeline({defaults: {duration: 1},
-  scrollTrigger: {
-    trigger: "#svg-stage",
-    scrub: true,
-    start: "top center",
-    end: "bottom center"
-  }})
-.to(".ball01", {duration: 0.01, autoAlpha: 1})
-.from(".theLine", {drawSVG: 0}, 0)
-.to(".ball01", {motionPath: {
-  path: ".theLine", 
-  align:".theLine",
-  alignOrigin: [0.5, 0.5],
-}}, 0)
-.add(pulses, 0);
-
-
-
-
-
-// 💚 This just adds the GSAP link to this pen, don't copy this bit
-import { GSAPInfoBar } from "https://codepen.io/GreenSock/pen/vYqpyLg.js"
-new GSAPInfoBar({ link: "https://gsap.com/docs/v3/Plugins/ScrollTrigger/"});
-// 💚 Happy tweening!
+  const main = gsap.timeline({defaults:{duration:1},
+    scrollTrigger:{
+      trigger:'#svg-stage',
+      scrub:true,
+      start:'top center',
+      end:'bottom center'
+    }
+  })
+  .to('.ball01',{duration:0.01,autoAlpha:1})
+  .from('.theLine',{drawSVG:0},0)
+  .to('.ball01',{motionPath:{
+    path:'.theLine',
+    align:'.theLine',
+    alignOrigin:[0.5,0.5]
+  }},0)
+  .add(pulses,0);
+}

--- a/static/js/gsap_main.js
+++ b/static/js/gsap_main.js
@@ -1,0 +1,68 @@
+// static/js/gsap_main.js
+// Gestion global de GSAP y ScrollSmoother
+
+(function(window){
+    const plugins = [
+        ScrollTrigger,
+        ScrollSmoother,
+        MotionPathPlugin,
+        MotionPathHelper,
+        MorphSVGPlugin,
+        Observer,
+        PixiPlugin,
+        ScrambleTextPlugin,
+        ScrollToPlugin,
+        SplitText,
+        TextPlugin,
+        CustomEase,
+        CustomBounce,
+        Flip,
+        Physics2DPlugin,
+        DrawSVGPlugin
+    ];
+
+    if (typeof gsap !== 'undefined') {
+        gsap.registerPlugin(...plugins);
+    }
+
+    let smootherInstance;
+
+    function initSmoother(){
+        if(!smootherInstance){
+            smootherInstance = ScrollSmoother.create({
+                wrapper: '#gsap-smoother-wrapper',
+                content: '#gsap-smoother-content',
+                smooth: 1,
+                effects: true
+            });
+        }
+        return smootherInstance;
+    }
+
+    const animations = [];
+
+    function registerAnimation(fn){
+        if(typeof fn === 'function'){
+            animations.push(fn);
+            if(document.readyState === 'complete'){
+                fn(gsap, initSmoother());
+            }
+        }
+    }
+
+    function runAnimations(){
+        const sm = initSmoother();
+        animations.forEach(fn => {
+            try{ fn(gsap, sm); }catch(e){ console.error(e); }
+        });
+    }
+
+    window.gsapApp = {
+        gsap,
+        registerAnimation,
+        getSmoother: initSmoother,
+        refresh: () => ScrollTrigger.refresh()
+    };
+
+    window.addEventListener('load', runAnimations);
+})(window);

--- a/templates/GSAP_Templates/clamp.html
+++ b/templates/GSAP_Templates/clamp.html
@@ -28,11 +28,10 @@
 </div>
 {% endblock %}
 {% block extra_js %}
-<script src="https://unpkg.co/gsap@3/dist/gsap.min.js"></script>
-<script src="https://assets.codepen.io/16327/ScrollTrigger.min.js?v=3.12"></script>
-<script src="https://assets.codepen.io/16327/ScrollSmoother.min.js?v=3.12"></script>
-<script src="https://assets.codepen.io/16327/DrawSVGPlugin3.min.js"></script>
-<script type="module" src="{{ url_for('static', filename='js/gsap_js/clamp.js') }}"></script>
+<script type="module">
+    import { initClampModule } from "{{ url_for('static', filename='js/gsap_js/clamp.js') }}";
+    window.gsapApp.registerAnimation(initClampModule);
+</script>
 
 
 {% endblock %}

--- a/templates/GSAP_Templates/funcion.html
+++ b/templates/GSAP_Templates/funcion.html
@@ -29,11 +29,10 @@
 </svg>
 {% endblock %}
 {% block extra_js %}
-<script src="https://s3-us-west-2.amazonaws.com/s.cdpn.io/16327/gsap-latest-beta.min.js"></script>
-<script src="https://s3-us-west-2.amazonaws.com/s.cdpn.io/16327/ScrollTrigger.min.js"></script>
-<script src="https://s3-us-west-2.amazonaws.com/s.cdpn.io/16327/DrawSVGPlugin3.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.2.6/MotionPathPlugin.min.js"></script>
-<script type="module" src="{{ url_for('static', filename='js/gsap_js/funcion.js') }}"></script>
+<script type="module">
+    import { initFuncionModule } from "{{ url_for('static', filename='js/gsap_js/funcion.js') }}";
+    window.gsapApp.registerAnimation(initFuncionModule);
+</script>
 
 
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -24,6 +24,8 @@
     {% block extra_css %}{% endblock %}
 </head>
 <body>
+    <div id="gsap-smoother-wrapper">
+    <div id="gsap-smoother-content">
     {% block navbar %}
     <!-- Navigation -->
     <nav class="navbar navbar-expand-lg navbar-light fixed-top" id="mainNav">
@@ -190,35 +192,14 @@
             }
         }
         
-        // Inicializar GSAP cuando el DOM esté listo
-        document.addEventListener('DOMContentLoaded', function() {
-            // Registrar plugins de GSAP
-            if (typeof gsap !== 'undefined') {
-                gsap.registerPlugin(
-                    MotionPathHelper,
-                    MotionPathPlugin,
-                    MorphSVGPlugin,
-                    Observer,
-                    PixiPlugin,
-                    ScrambleTextPlugin,
-                    ScrollTrigger,
-                    ScrollSmoother,
-                    ScrollToPlugin,
-                    SplitText,
-                    TextPlugin,
-                    CustomEase,
-                    CustomBounce,
-                    Flip
-                );
-                gsap.registerPlugin(ScrollTrigger, TextPlugin, CustomEase, CustomBounce, Flip, MotionPathPlugin);
-                console.log('GSAP plugins registrados correctamente');
-            }
-        });
     </script>
-    
-    <!-- Custom Scripts -->
+
+    <!-- Framework Scripts -->
+    <script src="{{ url_for('static', filename='js/gsap_main.js') }}"></script>
     <script src="{{ url_for('static', filename='js/main.js') }}"></script>
-    
+
     {% block extra_js %}{% endblock %}
+    </div> <!-- #gsap-smoother-content -->
+    </div> <!-- #gsap-smoother-wrapper -->
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -577,10 +577,6 @@
 {% endblock %}
 
 {% block extra_js %}
-<script src="https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/gsap.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/ScrollTrigger.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/pixi.js/7.2.4/browser/pixi.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/ExpoScaleEase.min.js"></script>
 <script src="{{ url_for('static', filename='js/emergency-system.js') }}"></script>
 <script src="{{ url_for('static', filename='js/confetti.js') }}"></script>
 <script src="{{ url_for('static', filename='js/presentation.js') }}"></script>


### PR DESCRIPTION
## Summary
- add global GSAP/ScrollSmoother wrapper in `base.html`
- add `gsap_main.js` to manage global plugins and smoother
- refactor example GSAP modules to use global instance
- clean GSAP imports from templates and index

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6844f692fd248332b131ffb9fdfc23c1