### PR TITLE
Refactor GSAP initialization

### DIFF
--- a/static/js/gsap_js/clamp.js
+++ b/static/js/gsap_js/clamp.js
@@ -1,103 +1,47 @@
-// rescue.js - JavaScript encapsulado
-(function() {
+(function(window){
   'use strict';
-  
-  // Namespace para evitar conflictos
-  const RescueModule = {
-    smoother: null,
-    
-    init: function() {
-      // Verificar que GSAP esté cargado
-      if (typeof gsap === 'undefined' || typeof ScrollTrigger === 'undefined' || typeof ScrollSmoother === 'undefined') {
-        console.error('RESCUE Module: GSAP, ScrollTrigger o ScrollSmoother no están cargados');
-        return;
+
+  function init({gsap}) {
+    if(!gsap) return;
+
+    gsap.from('.rescue-7x9k-draw', {
+      drawSVG: '0%',
+      ease: 'expo.out',
+      scrollTrigger: {
+        trigger: '.rescue-7x9k-heading',
+        start: 'clamp(top center)',
+        scrub: true,
+        pin: '.rescue-7x9k-pin',
+        pinSpacing: false,
+        markers: false,
+        id: 'rescue-svg-trigger'
       }
-      
-      // Registrar plugins
-      gsap.registerPlugin(ScrollTrigger, ScrollSmoother);
-      
-      this.smoother = ScrollSmoother.create({
-        wrapper: '#rescue-smooth-wrapper',
-        content: '#rescue-smooth-content',
-        smooth: 2,
-        effects: true,
-        smoothTouch: 0.1
-      });
-      
-      // Animación del SVG
-      gsap.from('.rescue-7x9k-draw', {
-        drawSVG: "0%",
-        ease: "expo.out",
+    });
+
+    gsap.utils.toArray('.rescue-7x9k-img').forEach((img, i) => {
+      const speed = img.getAttribute('data-speed');
+      gsap.to(img, {
+        yPercent: -30 * (i + 1),
+        ease: 'none',
         scrollTrigger: {
-          trigger: '.rescue-7x9k-heading',
-          start: "clamp(top center)",
-          scrub: true,
-          pin: '.rescue-7x9k-pin',
-          pinSpacing: false,
-          markers: false,
-          id: 'rescue-svg-trigger'
+          trigger: '.rescue-7x9k-images',
+          start: 'top bottom',
+          end: 'bottom top',
+          scrub: speed,
+          id: `rescue-img-${i}`
         }
       });
-      
-      // Parallax effect para las imágenes
-      gsap.utils.toArray('.rescue-7x9k-img').forEach((img, i) => {
-        const speed = img.getAttribute('data-speed');
-        gsap.to(img, {
-          yPercent: -30 * (i + 1),
-          ease: "none",
-          scrollTrigger: {
-            trigger: '.rescue-7x9k-images',
-            start: "top bottom",
-            end: "bottom top",
-            scrub: speed,
-            id: `rescue-img-${i}`
-          }
-        });
-      });
-      
-      // Fade in inicial
-      gsap.fromTo('.rescue-7x9k-module',
-        { opacity: 0 },
-        { opacity: 1, duration: 1, ease: "power2.out" }
-      );
-    },
-    
-    destroy: function() {
-      // Limpiar ScrollTriggers específicos del módulo
-      ScrollTrigger.getAll().forEach(st => {
-        if (st.vars.id && st.vars.id.startsWith('rescue-')) {
-          st.kill();
-        }
-      });
-      
-      // Destruir smoother
-      if (this.smoother) {
-        this.smoother.kill();
-        this.smoother = null;
-      }
-    },
-    
-    refresh: function() {
-      if (this.smoother) {
-        this.smoother.refresh();
-      }
-      ScrollTrigger.refresh();
-    }
-  };
-  
-  // Inicializar cuando el DOM esté listo
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', () => RescueModule.init());
-  } else {
-    RescueModule.init();
+    });
+
+    gsap.fromTo('.rescue-7x9k-module',
+      { opacity: 0 },
+      { opacity: 1, duration: 1, ease: 'power2.out' }
+    );
   }
-  
-  // Exponer API pública si es necesario
-  window.RescueModule = {
-    refresh: () => RescueModule.refresh(),
-    destroy: () => RescueModule.destroy()
-   
-  };
-  window.smoother.kill();
-  window.smoother = null;
-})();
+
+  if(window.GSAP_MAIN){
+    window.GSAP_MAIN.registerModule(init);
+  }else{
+    document.addEventListener('DOMContentLoaded', () => init({gsap}));
+  }
+})(window);

--- a/static/js/gsap_main.js
+++ b/static/js/gsap_main.js
@@ -1,0 +1,49 @@
+const GSAP_MAIN = (() => {
+  const registered = [];
+  let smoother = null;
+
+  function init() {
+    if (typeof gsap === 'undefined' || typeof ScrollSmoother === 'undefined') {
+      console.error('GSAP o ScrollSmoother no disponibles');
+      return;
+    }
+
+    gsap.registerPlugin(
+      ScrollTrigger,
+      ScrollSmoother,
+      ScrollToPlugin,
+      DrawSVGPlugin,
+      MotionPathPlugin
+    );
+
+    smoother = ScrollSmoother.create({
+      wrapper: '#gsap-smoother-wrapper',
+      content: '#gsap-smoother-content',
+      smooth: 1,
+      effects: true,
+      smoothTouch: 0.1
+    });
+
+    registered.forEach(fn => fn({ gsap, ScrollTrigger, smoother }));
+  }
+
+  function registerModule(fn) {
+    if (typeof fn === 'function') {
+      if (smoother) {
+        fn({ gsap, ScrollTrigger, smoother });
+      } else {
+        registered.push(fn);
+      }
+    }
+  }
+
+  function refresh() {
+    ScrollTrigger.refresh();
+    if (smoother) smoother.refresh();
+  }
+
+  return { init, registerModule, refresh, get smoother() { return smoother; } };
+})();
+
+document.addEventListener('DOMContentLoaded', GSAP_MAIN.init);
+window.GSAP_MAIN = GSAP_MAIN;

--- a/templates/GSAP_Templates/clamp.html
+++ b/templates/GSAP_Templates/clamp.html
@@ -7,9 +7,7 @@
 <!-- Módulo RESCUE encapsulado -->
 <div class="rescue-7x9k-wrapper">
   <div class="rescue-7x9k-module">
-    <div class="rescue-7x9k-smooth-wrapper" id="rescue-smooth-wrapper">
-      <div class="rescue-7x9k-smooth-content" id="rescue-smooth-content">
-        <section class="rescue-7x9k-hero">
+    <section class="rescue-7x9k-hero">
           <div class="rescue-7x9k-heading">
             <div class="rescue-7x9k-pin">
               <h1 class="rescue-7x9k-title">
@@ -29,8 +27,6 @@
           </div>
         </section>
         <section class="rescue-7x9k-spacer"></section>
-      </div>
-    </div>
   </div>
 </div>
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -85,7 +85,11 @@
     </nav> -->
     {% endblock %}
 
-    {% block content %}{% endblock %}
+    <div id="gsap-smoother-wrapper">
+        <div id="gsap-smoother-content">
+            {% block content %}{% endblock %}
+        </div>
+    </div>
 
     <!-- Footer -->
     {% block footer %}
@@ -148,32 +152,16 @@
             }
         }
         
-        // Inicializar GSAP cuando el DOM esté listo
-        document.addEventListener('DOMContentLoaded', function() {
-            // Registrar plugins de GSAP
-            if (typeof gsap !== 'undefined') {
-                gsap.registerPlugin(
-                    MotionPathHelper,
-                    MotionPathPlugin,
-                    MorphSVGPlugin,
-                    Observer,
-                    PixiPlugin,
-                    ScrambleTextPlugin,
-                    ScrollTrigger,
-                    ScrollSmoother,
-                    ScrollToPlugin,
-                    SplitText,
-                    TextPlugin,
-                    CustomEase,
-                    CustomBounce,
-                    Flip
-                );
-                gsap.registerPlugin(ScrollTrigger, TextPlugin, CustomEase, CustomBounce, Flip, MotionPathPlugin);
-                console.log('GSAP plugins registrados correctamente');
-            }
-        });
     </script>
-    
+
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/gsap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/ScrollTrigger.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/ScrollSmoother.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/ScrollToPlugin.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/DrawSVGPlugin.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/MotionPathPlugin.min.js"></script>
+    <script type="module" src="{{ url_for('static', filename='js/gsap_main.js') }}"></script>
+
     <!-- Custom Scripts -->
     
     {% block extra_js %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -449,10 +449,4 @@
 {% endblock %}
 
 {%block extra_js%}
-<script src="https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/gsap.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/ScrollSmoother.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/ScrollTrigger.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/DrawSVGPlugin.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/gsap@3.13.0/dist/MotionPathPlugin.min.js"></script>
-
-{%endblock%}
+{% endblock %}


### PR DESCRIPTION
## Summary
- add global ScrollSmoother instance and utilities
- wrap base template content for smoother
- load GSAP CDN libs from base template
- use new global gsap_main utilities
- refactor clamp module to use global instance
- clean GSAP scripts from index

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6844fad519fc833298c9023116576b0c