### PR TITLE
Add top 10 company activity to dashboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -88,7 +88,6 @@ def admin_dashboard():
     user = session.get('user', {})
     empresa_id = user.get('empresa_id')
     activity_data = {}
-    print(user)
     # if empresa_id:
     #     res = g.api_client.get_empresa_activity(empresa_id)
     #     if res.ok:
@@ -99,9 +98,7 @@ def admin_dashboard():
     if user.get('role') == 'super_admin':
         res = g.api_client.get_admin_activity()
         if res.ok:
-            print("entra a res")
             activity_logs = res.json().get('data', [])
-            print(f"lo de res es {activity_logs}")
             from collections import Counter
             counts = Counter(
                 (log.get('empresa_id') or log.get('empresaId'))

--- a/app.py
+++ b/app.py
@@ -112,6 +112,11 @@ def admin_dashboard():
                 {'empresa_id': eid, 'count': cnt}
                 for eid, cnt in counts.most_common(10)
             ]
+            activity_data = {
+                'labels': [entry['empresa_id'] for entry in top_activity],
+                'values': [entry['count'] for entry in top_activity],
+                'label': 'Logs por empresa'
+            }
 
     return render_template(
         'admin/dashboard.html',

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -293,16 +293,14 @@
             </tr>
           </thead>
           <tbody id="activityLogsTableBody">
-            {% for log in activity_logs[:10] %}
+            {% for entry in top_activity %}
             <tr class="border-t border-gray-100 dark:border-gray-700">
               <td class="px-2 py-1">{{ loop.index }}</td>
-              <td class="px-2 py-1 font-mono text-xs">{{ log.get('empresa_id') or log.get('empresaId') or '-' }}</td>
-              <td class="px-2 py-1">
-                {{ log.get('accion') or log.get('action') or log.get('evento') or log.get('message') or log | tojson }}
-              </td>
+              <td class="px-2 py-1 font-mono text-xs">{{ entry.empresa_id }}</td>
+              <td class="px-2 py-1">{{ entry.count }}</td>
             </tr>
             {% endfor %}
-            {% if not activity_logs %}
+            {% if not top_activity %}
             <tr class="border-t border-gray-100 dark:border-gray-700">
               <td colspan="3" class="px-2 py-4 text-center text-gray-500">Sin datos</td>
             </tr>

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -393,6 +393,41 @@ function downloadChart(chartId) {
     window.dashboard.charts.download(chartId);
   }
 }
+document.addEventListener('DOMContentLoaded', function () {
+  const ctx = document.getElementById('dashboardChart')?.getContext('2d');
+  if (!ctx || typeof Chart === 'undefined') return;
+
+  const data = window.ACTIVITY_DATA || { labels: [], values: [], label: 'Actividad' };
+  if (!data.labels || data.labels.length === 0) {
+    data.labels = ['Sin datos'];
+    data.values = [0];
+  }
+
+  new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: data.labels,
+      datasets: [{
+        label: data.label || 'Actividad',
+        data: data.values,
+        borderColor: 'rgb(147, 51, 234)',
+        backgroundColor: 'rgba(147, 51, 234, 0.2)',
+        tension: 0.4,
+        fill: true,
+        pointBackgroundColor: '#ffffff',
+        pointBorderColor: 'rgb(147, 51, 234)',
+        borderWidth: 2
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      scales: {
+        y: { beginAtZero: true }
+      }
+    }
+  });
+});
 </script>
 {% endblock %}
 

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -394,29 +394,26 @@ function downloadChart(chartId) {
   }
 }
 document.addEventListener('DOMContentLoaded', function () {
-  const ctx = document.getElementById('dashboardChart')?.getContext('2d');
-  if (!ctx || typeof Chart === 'undefined') return;
+  const canvas = document.getElementById('dashboardChart');
+  if (!canvas || typeof Chart === 'undefined') return;
+  const ctx = canvas.getContext('2d');
 
-  const data = window.ACTIVITY_DATA || { labels: [], values: [], label: 'Actividad' };
-  if (!data.labels || data.labels.length === 0) {
-    data.labels = ['Sin datos'];
-    data.values = [0];
-  }
+  const raw = window.ACTIVITY_DATA || { labels: [], values: [], label: 'Actividad' };
+  const labels = raw.labels && raw.labels.length ? raw.labels : ['Sin datos'];
+  const values = raw.values && raw.values.length ? raw.values : [0];
+
+  const colors = labels.map((_, i) => `hsl(${(i * 37) % 360},70%,60%)`);
 
   new Chart(ctx, {
-    type: 'line',
+    type: 'bar',
     data: {
-      labels: data.labels,
+      labels,
       datasets: [{
-        label: data.label || 'Actividad',
-        data: data.values,
-        borderColor: 'rgb(147, 51, 234)',
-        backgroundColor: 'rgba(147, 51, 234, 0.2)',
-        tension: 0.4,
-        fill: true,
-        pointBackgroundColor: '#ffffff',
-        pointBorderColor: 'rgb(147, 51, 234)',
-        borderWidth: 2
+        label: raw.label || 'Actividad',
+        data: values,
+        backgroundColor: colors,
+        borderColor: colors,
+        borderWidth: 1
       }]
     },
     options: {
@@ -424,6 +421,9 @@ document.addEventListener('DOMContentLoaded', function () {
       maintainAspectRatio: false,
       scales: {
         y: { beginAtZero: true }
+      },
+      plugins: {
+        legend: { display: false }
       }
     }
   });


### PR DESCRIPTION
## Summary
- aggregate admin activity logs into top_activity in the Flask route
- build chart data from these aggregated values
- show the top companies and their log counts in dashboard.html

## Testing
- `python -m py_compile app.py python_api_client.py`

------
https://chatgpt.com/codex/tasks/task_e_685a34623a9c83329bef8433077e6d5c