### PR TITLE
Implement role-based view restrictions

### DIFF
--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -62,11 +62,11 @@
       
       <button class="navbar__user">
         <div class="navbar__user-avatar">
-          <span class="user-initials">AD</span>
+          <span class="user-initials">{{ current_user.name | user_initials if current_user else 'U' }}</span>
         </div>
         <div class="navbar__user-info">
-          <p class="navbar__user-name">Admin</p>
-          <p class="navbar__user-role">Administrador</p>
+          <p class="navbar__user-name">{{ current_user.name if current_user else 'Usuario' }}</p>
+          <p class="navbar__user-role">{{ current_user.role|title if current_user else '' }}</p>
         </div>
         <i class="fas fa-chevron-down navbar__user-chevron"></i>
       </button>
@@ -87,11 +87,11 @@
       <div class="sidebar__profile">
         <div class="sidebar__profile-content">
           <div class="sidebar__profile-avatar">
-            <span class="user-initials">AD</span>
+            <span class="user-initials">{{ current_user.name | user_initials if current_user else 'U' }}</span>
           </div>
           <div class="sidebar__profile-info">
-            <p class="sidebar__profile-name">Admin Principal</p>
-            <p class="sidebar__profile-role">Super Admin</p>
+            <p class="sidebar__profile-name">{{ current_user.name if current_user else 'Usuario' }}</p>
+            <p class="sidebar__profile-role">{{ current_user.role|title if current_user else '' }}</p>
           </div>
         </div>
       </div>
@@ -100,6 +100,7 @@
       <nav class="sidebar__nav">
         <div class="sidebar__nav-section">
           <div class="sidebar__nav-list" id="sidebarNav">
+            {% if current_user and current_user.get('role') == 'super_admin' %}
             <a href="{{ url_for('admin_dashboard') }}" class="sidebar__link {% if active_page=='dashboard' %}sidebar__link--active{% endif %}">
               <div class="sidebar__link-icon"><i class="fas fa-tachometer-alt"></i></div>
               <span class="sidebar__link-text">Dashboard</span>
@@ -108,21 +109,32 @@
               <div class="sidebar__link-icon"><i class="fas fa-building"></i></div>
               <span class="sidebar__link-text">Empresas</span>
             </a>
+            {% endif %}
+            <a href="{{ url_for('admin_users') }}" class="sidebar__link {% if active_page=='users' %}sidebar__link--active{% endif %}">
+              <div class="sidebar__link-icon"><i class="fas fa-users"></i></div>
+              <span class="sidebar__link-text">Usuarios</span>
+            </a>
             <a href="{{ url_for('admin_stats') }}" class="sidebar__link {% if active_page=='stats' %}sidebar__link--active{% endif %}">
               <div class="sidebar__link-icon"><i class="fas fa-chart-bar"></i></div>
               <span class="sidebar__link-text">Estadísticas</span>
+            </a>
+            <a href="{{ url_for('admin_hardware') }}" class="sidebar__link {% if active_page=='hardware' %}sidebar__link--active{% endif %}">
+              <div class="sidebar__link-icon"><i class="fas fa-microchip"></i></div>
+              <span class="sidebar__link-text">Hardware</span>
             </a>
           </div>
         </div>
       </nav>
       
+      {% if current_user and current_user.get('role') == 'super_admin' %}
       <!-- Company Selector -->
-      <div class="sidebar__company-selector admin-only">
+      <div class="sidebar__company-selector">
         <label class="sidebar__company-label">Empresa Actual</label>
         <select id="sidebarEmpresaSelector" class="sidebar__company-select">
           <option value="">Todas las empresas</option>
         </select>
       </div>
+      {% endif %}
       
       <!-- Logout -->
       <div class="sidebar__logout">
@@ -238,8 +250,9 @@
 
     <!-- Activity Lists -->
     <div class="grid grid-cols-1 xl:grid-cols-2 gap-6 mb-8">
+      {% if current_user and current_user.get('role') == 'super_admin' %}
       <!-- Recent Companies -->
-      <div class="glass-card admin-only">
+      <div class="glass-card">
         <div class="p-6 border-b border-gray-100 dark:border-gray-700">
           <div class="flex items-center justify-between">
             <div>
@@ -262,6 +275,7 @@
           </div>
         </div>
       </div>
+      {% endif %}
 
       <!-- Recent Users -->
       <div class="glass-card">
@@ -289,8 +303,9 @@
       </div>
     </div>
 
+    {% if current_user and current_user.get('role') == 'super_admin' %}
     <!-- Top Activity Table -->
-    <div class="glass-card admin-only mt-6">
+    <div class="glass-card mt-6">
       <div class="p-6 border-b border-gray-100 dark:border-gray-700">
         <h3 class="text-xl font-bold text-gray-900 dark:text-white">Top 10 Actividad</h3>
         <p class="text-sm text-gray-500 dark:text-gray-400">Empresas con más logs</p>
@@ -321,6 +336,7 @@
         </table>
       </div>
     </div>
+    {% endif %}
     {% endblock %}
   </main>
 </div>

--- a/templates/admin/hardware.html
+++ b/templates/admin/hardware.html
@@ -1,0 +1,9 @@
+{% extends "admin/dashboard.html" %}
+{% block title %}Hardware - Sistema Multi-Tenant{% endblock %}
+
+{% block main_content %}
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+  <h1 class="text-3xl font-bold text-gray-900">Gestión de Hardware</h1>
+  <p class="text-gray-600 mt-2">Sección de administración de hardware.</p>
+</div>
+{% endblock %}

--- a/templates/errors/403.html
+++ b/templates/errors/403.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Acceso denegado</title>
+</head>
+<body>
+    <h1>403 - Acceso denegado</h1>
+    <p>No tienes permiso para acceder a esta página.</p>
+</body>
+</html>

--- a/templates/users.html
+++ b/templates/users.html
@@ -46,11 +46,11 @@
         <div class="relative">
           <button class="user-info-btn flex items-center space-x-2 p-2 rounded-lg hover:bg-gray-100 transition-colors">
             <div class="w-8 h-8 bg-blue-600 rounded-full flex items-center justify-center">
-              <span class="text-white text-sm font-medium user-initials">U</span>
+              <span class="text-white text-sm font-medium user-initials">{{ current_user.name | user_initials if current_user else 'U' }}</span>
             </div>
             <div class="hidden md:block text-left">
-              <p class="text-sm font-medium text-gray-900 user-name">Usuario</p>
-              <p class="text-xs text-gray-500 user-role">Rol</p>
+              <p class="text-sm font-medium text-gray-900 user-name">{{ current_user.name if current_user else 'Usuario' }}</p>
+              <p class="text-xs text-gray-500 user-role">{{ current_user.role|title if current_user else '' }}</p>
             </div>
           </button>
         </div>
@@ -74,24 +74,31 @@
     
     <nav class="mt-8">
       <div class="px-4 space-y-2">
-        <a href="/admin" class="flex items-center px-4 py-3 text-gray-700 rounded-lg hover:bg-blue-50 transition-colors">
+        {% if current_user and current_user.get('role') == 'super_admin' %}
+        <a href="{{ url_for('admin_dashboard') }}" class="flex items-center px-4 py-3 text-gray-700 rounded-lg hover:bg-blue-50 transition-colors">
           <i class="fas fa-tachometer-alt mr-3"></i>
           Dashboard
         </a>
-        
-        <a href="/admin/empresas" class="admin-only flex items-center px-4 py-3 text-gray-700 rounded-lg hover:bg-blue-50 transition-colors">
+
+        <a href="{{ url_for('admin_empresas') }}" class="flex items-center px-4 py-3 text-gray-700 rounded-lg hover:bg-blue-50 transition-colors">
           <i class="fas fa-building mr-3"></i>
           Empresas
         </a>
-        
-        <a href="/admin/users" class="flex items-center px-4 py-3 bg-blue-600 text-white rounded-lg">
+        {% endif %}
+
+        <a href="{{ url_for('admin_users') }}" class="flex items-center px-4 py-3 {% if active_page=='users' %}bg-blue-600 text-white{% else %}text-gray-700 hover:bg-blue-50{% endif %} rounded-lg">
           <i class="fas fa-users mr-3"></i>
           Usuarios
         </a>
-        
-        <a href="/admin/stats" class="flex items-center px-4 py-3 text-gray-700 rounded-lg hover:bg-blue-50 transition-colors">
+
+        <a href="{{ url_for('admin_stats') }}" class="flex items-center px-4 py-3 {% if active_page=='stats' %}bg-blue-600 text-white{% else %}text-gray-700 hover:bg-blue-50{% endif %} rounded-lg">
           <i class="fas fa-chart-bar mr-3"></i>
           Estadísticas
+        </a>
+
+        <a href="{{ url_for('admin_hardware') }}" class="flex items-center px-4 py-3 {% if active_page=='hardware' %}bg-blue-600 text-white{% else %}text-gray-700 hover:bg-blue-50{% endif %} rounded-lg">
+          <i class="fas fa-microchip mr-3"></i>
+          Hardware
         </a>
       </div>
     </nav>


### PR DESCRIPTION
## Summary
- add a `role_required` decorator in `app.py`
- restrict admin and empresa routes according to user role
- add new `/admin/hardware` view and template
- provide simple 403 error page
- show navigation links according to logged-in user's role

## Testing
- `python -m py_compile app.py python_api_client.py`


------
https://chatgpt.com/codex/tasks/task_e_6866b0d220548332ac22e9db22539bb9