### PR TITLE
Add strict validation to admin modals

### DIFF
--- a/static/js/empresas/empresas-modals.js
+++ b/static/js/empresas/empresas-modals.js
@@ -770,7 +770,43 @@ class EmpresasModals {
     
     try {
       const formData = this.buildFormData();
-      
+
+      // Validar campos obligatorios
+      if (!formData.nombre) {
+        this.showNotification('El nombre de la empresa es obligatorio', 'error');
+        return;
+      }
+
+      if (!formData.username) {
+        this.showNotification('El usuario de la empresa es obligatorio', 'error');
+        return;
+      }
+
+      if (!formData.email) {
+        this.showNotification('El correo de la empresa es obligatorio', 'error');
+        return;
+      }
+
+      if (!formData.ubicacion) {
+        this.showNotification('La ubicación de la empresa es obligatoria', 'error');
+        return;
+      }
+
+      if (!formData.descripcion) {
+        this.showNotification('La descripción de la empresa es obligatoria', 'error');
+        return;
+      }
+
+      if (!formData.tipo_empresa_id) {
+        this.showNotification('Debe seleccionar un tipo de empresa', 'error');
+        return;
+      }
+
+      if (!this.currentEditingEmpresa && !formData.password) {
+        this.showNotification('La contraseña es obligatoria', 'error');
+        return;
+      }
+
       // Validate that at least one sede and one role are provided
       if (!formData.sedes || formData.sedes.length === 0) {
         this.showNotification('Error: Debe agregar al menos una sede para la empresa', 'error');

--- a/static/js/usuarios/usuarios-modals.js
+++ b/static/js/usuarios/usuarios-modals.js
@@ -394,25 +394,41 @@ editForm.addEventListener('submit', (e) => {
         rol: document.getElementById('editUserRol').value
       };
 
-      // Validate form con mensajes más específicos
+      // Validar formulario y construir mensajes en español
       const validationErrors = [];
-      
+
       if (!formData.nombre || formData.nombre.length < 2) {
         validationErrors.push('El nombre es obligatorio y debe tener al menos 2 caracteres');
       }
-      
+
+      if (!formData.email) {
+        validationErrors.push('El correo es obligatorio');
+      } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email)) {
+        validationErrors.push('El formato del correo no es válido');
+      }
+
       if (!formData.cedula) {
         validationErrors.push('La cédula es obligatoria');
       } else if (!/^\d{6,15}$/.test(formData.cedula)) {
         validationErrors.push('La cédula debe contener solo números y tener entre 6 y 15 dígitos');
       }
-      
-      if (formData.telefono && !/^\d{7,15}$/.test(formData.telefono)) {
+
+      if (!formData.telefono) {
+        validationErrors.push('El teléfono es obligatorio');
+      } else if (!/^\d{7,15}$/.test(formData.telefono)) {
         validationErrors.push('El teléfono debe contener solo números y tener entre 7 y 15 dígitos');
       }
-      
-      if (formData.email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email)) {
-        validationErrors.push('El formato del email no es válido');
+
+      if (!formData.sede) {
+        validationErrors.push('Debe seleccionar una sede');
+      }
+
+      if (!formData.tipo_turno) {
+        validationErrors.push('Debe seleccionar un tipo de turno');
+      }
+
+      if (!formData.rol) {
+        validationErrors.push('Debe seleccionar un rol');
       }
       
       if (validationErrors.length > 0) {
@@ -826,25 +842,41 @@ editForm.addEventListener('submit', (e) => {
         rol: document.getElementById('createUserRol').value
       };
 
-      // Validate form con mensajes más específicos
+      // Validar formulario y construir mensajes en español
       const validationErrors = [];
-      
+
       if (!formData.nombre || formData.nombre.length < 2) {
         validationErrors.push('El nombre es obligatorio y debe tener al menos 2 caracteres');
       }
-      
+
+      if (!formData.email) {
+        validationErrors.push('El correo es obligatorio');
+      } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email)) {
+        validationErrors.push('El formato del correo no es válido');
+      }
+
       if (!formData.cedula) {
         validationErrors.push('La cédula es obligatoria');
       } else if (!/^\d{6,15}$/.test(formData.cedula)) {
         validationErrors.push('La cédula debe contener solo números y tener entre 6 y 15 dígitos');
       }
-      
-      if (formData.telefono && !/^\d{7,15}$/.test(formData.telefono)) {
+
+      if (!formData.telefono) {
+        validationErrors.push('El teléfono es obligatorio');
+      } else if (!/^\d{7,15}$/.test(formData.telefono)) {
         validationErrors.push('El teléfono debe contener solo números y tener entre 7 y 15 dígitos');
       }
-      
-      if (formData.email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email)) {
-        validationErrors.push('El formato del email no es válido');
+
+      if (!formData.sede) {
+        validationErrors.push('Debe seleccionar una sede');
+      }
+
+      if (!formData.tipo_turno) {
+        validationErrors.push('Debe seleccionar un tipo de turno');
+      }
+
+      if (!formData.rol) {
+        validationErrors.push('Debe seleccionar un rol');
       }
       
       if (validationErrors.length > 0) {

--- a/templates/admin/users.html
+++ b/templates/admin/users.html
@@ -351,7 +351,7 @@
               <label for="editUserTelefono" class="block text-sm font-semibold text-white/90 dark:text-gray-200 mb-2">
                 <i class="fas fa-phone text-green-400 mr-2"></i>Teléfono
               </label>
-              <input type="tel" id="editUserTelefono" class="ios-blur-input" placeholder="Número de teléfono">
+              <input type="tel" id="editUserTelefono" class="ios-blur-input" required placeholder="Número de teléfono">
             </div>
             
             <!-- Sede -->
@@ -487,7 +487,7 @@
               <label for="createUserEmail" class="block text-sm font-semibold text-white/90 dark:text-gray-200 mb-2">
                 <i class="fas fa-envelope text-purple-400 mr-2"></i>Email
               </label>
-              <input type="email" id="createUserEmail" class="ios-blur-input" placeholder="usuario@empresa.com">
+              <input type="email" id="createUserEmail" class="ios-blur-input" required placeholder="usuario@empresa.com">
             </div>
             
             <!-- Cédula -->
@@ -503,7 +503,7 @@
               <label for="createUserTelefono" class="block text-sm font-semibold text-white/90 dark:text-gray-200 mb-2">
                 <i class="fas fa-phone text-green-400 mr-2"></i>Teléfono
               </label>
-              <input type="tel" id="createUserTelefono" class="ios-blur-input" placeholder="Número de teléfono">
+              <input type="tel" id="createUserTelefono" class="ios-blur-input" required placeholder="Número de teléfono">
             </div>
             
             <!-- Sede -->


### PR DESCRIPTION
## Summary
- require email/phone when creating a user
- validate all fields in user and company forms before submitting
- enforce company modal mandatory values

## Testing
- `pytest -q` *(fails: ConnectionRefusedError)*

------
https://chatgpt.com/codex/tasks/task_e_686de30d69e88332865814c8cde51111