### PR TITLE
Switch backend auth to cookies

### DIFF
--- a/dashboard_data_providers.py
+++ b/dashboard_data_providers.py
@@ -9,18 +9,18 @@ import random
 from datetime import datetime, timedelta
 from typing import List, Dict, Any
 from python_api_client import EndpointTestClient
-from flask import session
+from flask import session, request
 import logging
 
 logger = logging.getLogger(__name__)
 
 
 class RealDashboardDataProvider:
-    """Provides dashboard data from real API endpoints"""
-    
-    def __init__(self, api_base_url: str, token: str = None):
+    """Provides dashboard data from real API endpoints."""
+
+    def __init__(self, api_base_url: str, cookies: Dict[str, str] = None):
         self.api_base_url = api_base_url
-        self.client = EndpointTestClient(api_base_url, token)
+        self.client = EndpointTestClient(api_base_url, cookies=cookies)
         self.dummy_provider = DashboardDataProvider()  # Fallback to dummy data
     
     def get_dashboard_data(self) -> Dict[str, Any]:
@@ -500,7 +500,7 @@ def get_dashboard_stats():
     try:
         if 'token' in session:
             from config import BACKEND_API_URL
-            real_provider = RealDashboardDataProvider(BACKEND_API_URL, session['token'])
+            real_provider = RealDashboardDataProvider(BACKEND_API_URL, request.cookies)
             return real_provider.get_dashboard_data()
     except Exception as e:
         logger.warning(f"Could not get real dashboard data: {e}")
@@ -515,7 +515,7 @@ def get_companies_stats():
     try:
         if 'token' in session:
             from config import BACKEND_API_URL
-            real_provider = RealDashboardDataProvider(BACKEND_API_URL, session['token'])
+            real_provider = RealDashboardDataProvider(BACKEND_API_URL, request.cookies)
             companies_response = real_provider.client.get_dashboard_recent_companies()
             if companies_response.ok:
                 return {
@@ -535,7 +535,7 @@ def get_detailed_statistics():
     try:
         if 'token' in session:
             from config import BACKEND_API_URL
-            real_provider = RealDashboardDataProvider(BACKEND_API_URL, session['token'])
+            real_provider = RealDashboardDataProvider(BACKEND_API_URL, request.cookies)
             performance_data = real_provider.get_system_performance()
             if performance_data:
                 return {
@@ -560,7 +560,7 @@ def get_hardware_data():
     try:
         if 'token' in session:
             from config import BACKEND_API_URL
-            real_provider = RealDashboardDataProvider(BACKEND_API_URL, session['token'])
+            real_provider = RealDashboardDataProvider(BACKEND_API_URL, request.cookies)
             hardware_stats = real_provider.get_hardware_stats()
             if hardware_stats:
                 return {

--- a/static/js/dashboard/super-admin-dashboard-enhanced.js
+++ b/static/js/dashboard/super-admin-dashboard-enhanced.js
@@ -8,33 +8,16 @@ class SuperAdminDashboardEnhanced extends SuperAdminDashboard {
 
     // 2. MEJORA: Mejor método de obtención de token
     getSessionToken() {
-        // Priorizar window.sessionToken
-        if (window.sessionToken && window.sessionToken !== 'None' && window.sessionToken !== 'null') {
-            return window.sessionToken;
-        }
-        
-        // Luego sessionStorage
-        const sessionToken = sessionStorage.getItem('token');
-        if (sessionToken && sessionToken !== 'null') {
-            return sessionToken;
-        }
-        
-        // Luego localStorage
-        const localToken = localStorage.getItem('token');
-        if (localToken && localToken !== 'null') {
-            return localToken;
-        }
-        
-        // Finalmente cookies
+        // Leer token únicamente desde las cookies
         const cookies = document.cookie.split(';');
         for (let cookie of cookies) {
             const [name, value] = cookie.trim().split('=');
-            if ((name === 'token' || name === 'session_token') && value && value !== 'null') {
+            if (name === 'auth_token' && value) {
                 return value;
             }
         }
-        
-        console.warn('No session token found. Dashboard will use fallback data.');
+
+        console.warn('No auth cookie found. Dashboard will use fallback data.');
         return null;
     }
 

--- a/static/js/dashboard/super-admin-dashboard.js
+++ b/static/js/dashboard/super-admin-dashboard.js
@@ -6,7 +6,6 @@
 class SuperAdminDashboard {
     constructor() {
         this.client = null;
-        this.token = null;
         this.activityChart = null;
         this.distributionChart = null;
         this.initializeClient();

--- a/templates/base.html
+++ b/templates/base.html
@@ -78,9 +78,6 @@
     <script>
         window.API_BASE_URL = '{{ api_url if api_url else "http://localhost:5000" }}';
         window.CURRENT_USER = '{% if current_user %}{{ current_user | tojson | safe }}{% else %}null{% endif %}';
-        {% if session.get('token') %}
-        window.INIT_TOKEN = "{{ session.get('token') }}";
-        {% endif %}
     </script>
     
     <!-- GSAP Configuration (Global) -->


### PR DESCRIPTION
## Summary
- forward auth cookies to the backend and stop using tokens
- update RealDashboardDataProvider to accept cookies
- adjust JS dashboard code to only read auth cookies
- clean token injection from templates

## Testing
- `python -m py_compile app.py dashboard_data_providers.py python_api_client.py`

------
https://chatgpt.com/codex/tasks/task_e_68707290b0948332aaf5d294a327d5c4