### PR TITLE
Switch to cookie-based authorization

### DIFF
--- a/dashboard_data_providers.py
+++ b/dashboard_data_providers.py
@@ -7,7 +7,7 @@ with real API calls to your backend later.
 
 import random
 from datetime import datetime, timedelta
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 from python_api_client import EndpointTestClient
 from flask import session
 import logging
@@ -17,10 +17,10 @@ logger = logging.getLogger(__name__)
 
 class RealDashboardDataProvider:
     """Provides dashboard data from real API endpoints"""
-    
-    def __init__(self, api_base_url: str, token: str = None):
+
+    def __init__(self, api_base_url: str, cookies: Optional[Dict[str, str]] = None):
         self.api_base_url = api_base_url
-        self.client = EndpointTestClient(api_base_url, token)
+        self.client = EndpointTestClient(api_base_url, cookies=cookies)
         self.dummy_provider = DashboardDataProvider()  # Fallback to dummy data
     
     def get_dashboard_data(self) -> Dict[str, Any]:
@@ -496,11 +496,11 @@ class CompanyTypesProvider:
 # Easy-to-use functions for templates
 def get_dashboard_stats():
     """Quick function to get dashboard stats for templates"""
-    # Try to get real data if we have a session token
+    # Try to get real data if we have backend cookies
     try:
-        if 'token' in session:
+        if 'backend_cookies' in session:
             from config import BACKEND_API_URL
-            real_provider = RealDashboardDataProvider(BACKEND_API_URL, session['token'])
+            real_provider = RealDashboardDataProvider(BACKEND_API_URL, session['backend_cookies'])
             return real_provider.get_dashboard_data()
     except Exception as e:
         logger.warning(f"Could not get real dashboard data: {e}")
@@ -511,11 +511,11 @@ def get_dashboard_stats():
 
 def get_companies_stats():
     """Quick function to get companies stats for templates"""
-    # Try to get real data if we have a session token
+    # Try to get real data if we have backend cookies
     try:
-        if 'token' in session:
+        if 'backend_cookies' in session:
             from config import BACKEND_API_URL
-            real_provider = RealDashboardDataProvider(BACKEND_API_URL, session['token'])
+            real_provider = RealDashboardDataProvider(BACKEND_API_URL, session['backend_cookies'])
             companies_response = real_provider.client.get_dashboard_recent_companies()
             if companies_response.ok:
                 return {
@@ -531,11 +531,11 @@ def get_companies_stats():
 
 def get_detailed_statistics():
     """Quick function to get detailed statistics for templates"""
-    # Try to get real data if we have a session token
+    # Try to get real data if we have backend cookies
     try:
-        if 'token' in session:
+        if 'backend_cookies' in session:
             from config import BACKEND_API_URL
-            real_provider = RealDashboardDataProvider(BACKEND_API_URL, session['token'])
+            real_provider = RealDashboardDataProvider(BACKEND_API_URL, session['backend_cookies'])
             performance_data = real_provider.get_system_performance()
             if performance_data:
                 return {
@@ -556,11 +556,11 @@ def get_detailed_statistics():
 
 def get_hardware_data():
     """Quick function to get hardware data for templates"""
-    # Try to get real data if we have a session token
+    # Try to get real data if we have backend cookies
     try:
-        if 'token' in session:
+        if 'backend_cookies' in session:
             from config import BACKEND_API_URL
-            real_provider = RealDashboardDataProvider(BACKEND_API_URL, session['token'])
+            real_provider = RealDashboardDataProvider(BACKEND_API_URL, session['backend_cookies'])
             hardware_stats = real_provider.get_hardware_stats()
             if hardware_stats:
                 return {

--- a/static/js/dashboard/super-admin-dashboard-enhanced.js
+++ b/static/js/dashboard/super-admin-dashboard-enhanced.js
@@ -8,33 +8,7 @@ class SuperAdminDashboardEnhanced extends SuperAdminDashboard {
 
     // 2. MEJORA: Mejor método de obtención de token
     getSessionToken() {
-        // Priorizar window.sessionToken
-        if (window.sessionToken && window.sessionToken !== 'None' && window.sessionToken !== 'null') {
-            return window.sessionToken;
-        }
-        
-        // Luego sessionStorage
-        const sessionToken = sessionStorage.getItem('token');
-        if (sessionToken && sessionToken !== 'null') {
-            return sessionToken;
-        }
-        
-        // Luego localStorage
-        const localToken = localStorage.getItem('token');
-        if (localToken && localToken !== 'null') {
-            return localToken;
-        }
-        
-        // Finalmente cookies
-        const cookies = document.cookie.split(';');
-        for (let cookie of cookies) {
-            const [name, value] = cookie.trim().split('=');
-            if ((name === 'token' || name === 'session_token') && value && value !== 'null') {
-                return value;
-            }
-        }
-        
-        console.warn('No session token found. Dashboard will use fallback data.');
+        // Tokens are no longer used. Authentication relies on cookies.
         return null;
     }
 

--- a/static/js/dashboard/super-admin-dashboard.js
+++ b/static/js/dashboard/super-admin-dashboard.js
@@ -13,8 +13,8 @@ class SuperAdminDashboard {
     }
 
     initializeClient() {
-        // Initialize API client with proxy
-        this.client = new EndpointTestClient('/proxy');
+        // Initialize API client with backend base URL
+        this.client = new EndpointTestClient(window.API_BASE_URL);
         
         // No necesitamos manejar tokens manualmente con cookies
         console.log('Using cookie-based authentication');

--- a/static/js/empresas/empresas-main.js
+++ b/static/js/empresas/empresas-main.js
@@ -65,7 +65,7 @@ class EmpresasMain {
       
       // Check if we have the endpoint test client
       if (typeof EndpointTestClient !== 'undefined') {
-        this.apiClient = new EndpointTestClient('/proxy');
+        this.apiClient = new EndpointTestClient(window.API_BASE_URL);
         console.log('✅ API client creado usando EndpointTestClient');
         return;
       }
@@ -85,32 +85,32 @@ class EmpresasMain {
    */
   createBasicApiClient() {
     return {
-      get_empresas: () => fetch('/proxy/api/empresas/'),
-      get_empresas_dashboard: () => fetch('/proxy/api/empresas/dashboard/all'),
-      get_empresa: (id) => fetch(`/proxy/api/empresas/${id}`),
+      get_empresas: () => fetch(`${window.API_BASE_URL}/api/empresas/`, { credentials: 'include' }),
+      get_empresas_dashboard: () => fetch(`${window.API_BASE_URL}/api/empresas/dashboard/all`, { credentials: 'include' }),
+      get_empresa: (id) => fetch(`${window.API_BASE_URL}/api/empresas/${id}`, { credentials: 'include' }),
       toggle_empresa_status: (id, activa) => 
-        fetch(`/proxy/api/empresas/${id}/toggle-status`, {
+        fetch(`${window.API_BASE_URL}/api/empresas/${id}/toggle-status`, {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ activa })
         }),
       create_empresa: (data) =>
-        fetch('/proxy/api/empresas/', {
+        fetch(`${window.API_BASE_URL}/api/empresas/`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(data)
         }),
       update_empresa: (id, data) =>
-        fetch(`/proxy/api/empresas/${id}`, {
+        fetch(`${window.API_BASE_URL}/api/empresas/${id}`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(data)
         }),
       delete_empresa: (id) =>
-        fetch(`/proxy/api/empresas/${id}`, {
+        fetch(`${window.API_BASE_URL}/api/empresas/${id}`, {
           method: 'DELETE'
         }),
-      get_tipos_empresa: () => fetch('/proxy/api/tipos_empresa')
+      get_tipos_empresa: () => fetch(`${window.API_BASE_URL}/api/tipos_empresa`, { credentials: 'include' })
     };
   }
 

--- a/static/js/empresas/empresas-modals.js
+++ b/static/js/empresas/empresas-modals.js
@@ -53,7 +53,7 @@ class EmpresasModals {
     } else if (window.apiClient) {
       this.apiClient = window.apiClient;
     } else if (typeof EndpointTestClient !== 'undefined') {
-      this.apiClient = new EndpointTestClient('/proxy');
+      this.apiClient = new EndpointTestClient(window.API_BASE_URL);
     } else {
       this.apiClient = this.createBasicApiClient();
     }
@@ -64,32 +64,32 @@ class EmpresasModals {
    */
   createBasicApiClient() {
     return {
-      get_empresas_dashboard: () => fetch('/proxy/api/empresas/dashboard/all'),
-      get_empresas: () => fetch('/proxy/api/empresas'),
-      get_empresa: (id) => fetch(`/proxy/api/empresas/${id}`),
+      get_empresas_dashboard: () => fetch(`${window.API_BASE_URL}/api/empresas/dashboard/all`, { credentials: 'include' }),
+      get_empresas: () => fetch(`${window.API_BASE_URL}/api/empresas`, { credentials: 'include' }),
+      get_empresa: (id) => fetch(`${window.API_BASE_URL}/api/empresas/${id}`, { credentials: 'include' }),
       toggle_empresa_status: (id, activa) => 
-        fetch(`/proxy/api/empresas/${id}/toggle-status`, {
+        fetch(`${window.API_BASE_URL}/api/empresas/${id}/toggle-status`, {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ activa })
         }),
       create_empresa: (data) =>
-        fetch('/proxy/api/empresas/', {
+        fetch(`${window.API_BASE_URL}/api/empresas/`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(data)
         }),
       update_empresa: (id, data) =>
-        fetch(`/proxy/api/empresas/${id}`, {
+        fetch(`${window.API_BASE_URL}/api/empresas/${id}`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(data)
         }),
       delete_empresa: (id) =>
-        fetch(`/proxy/api/empresas/${id}`, {
+        fetch(`${window.API_BASE_URL}/api/empresas/${id}`, {
           method: 'DELETE'
         }),
-      get_tipos_empresa: () => fetch('/proxy/api/tipos_empresa')
+      get_tipos_empresa: () => fetch(`${window.API_BASE_URL}/api/tipos_empresa`, { credentials: 'include' })
     };
   }
 

--- a/static/js/hardware/hardware-main.js
+++ b/static/js/hardware/hardware-main.js
@@ -77,10 +77,10 @@ class HardwareMain {
       console.log('🔗 Inicializando API client...');
       
       // Check if proxy is available
-      const healthResponse = await fetch('/proxy/health');
+      const healthResponse = await fetch(`${window.API_BASE_URL}/health`, { credentials: 'include' });
       
       if (healthResponse.ok) {
-        this.apiClient = new EndpointTestClient('/proxy');
+        this.apiClient = new EndpointTestClient(window.API_BASE_URL);
         console.log('✅ API Client inicializado');
         
         // Make API client available to core module

--- a/static/js/usuarios-main.js
+++ b/static/js/usuarios-main.js
@@ -48,7 +48,7 @@ class UsuariosMain {
   async setupApiClient() {
     // Use global API client if available
     if (window.EndpointTestClient) {
-      this.apiClient = new window.EndpointTestClient('/proxy');
+      this.apiClient = new window.EndpointTestClient(window.API_BASE_URL);
       console.log('✅ Usando API client global');
     } else {
       console.error('❌ API client global no disponible');

--- a/static/js/usuarios/usuarios-modals.js
+++ b/static/js/usuarios/usuarios-modals.js
@@ -51,7 +51,7 @@ class UsuariosModals {
     } else if (window.apiClient) {
       this.apiClient = window.apiClient;
     } else if (typeof EndpointTestClient !== 'undefined') {
-      this.apiClient = new EndpointTestClient('/proxy');
+      this.apiClient = new EndpointTestClient(window.API_BASE_URL);
     } else {
       this.apiClient = this.createBasicApiClient();
     }
@@ -62,28 +62,28 @@ class UsuariosModals {
    */
   createBasicApiClient() {
     return {
-      get_usuarios_by_empresa: (empresaId) => fetch(`/proxy/empresas/${empresaId}/usuarios`),
-      get_usuario: (empresaId, userId) => fetch(`/proxy/empresas/${empresaId}/usuarios/${userId}`),
+      get_usuarios_by_empresa: (empresaId) => fetch(`${window.API_BASE_URL}/empresas/${empresaId}/usuarios`, { credentials: 'include' }),
+      get_usuario: (empresaId, userId) => fetch(`${window.API_BASE_URL}/empresas/${empresaId}/usuarios/${userId}`, { credentials: 'include' }),
       toggle_usuario_status: (empresaId, userId, activo) => 
-        fetch(`/proxy/empresas/${empresaId}/usuarios/${userId}/toggle-status`, {
+        fetch(`${window.API_BASE_URL}/empresas/${empresaId}/usuarios/${userId}/toggle-status`, {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ activo })
         }),
       update_usuario: (empresaId, userId, data) =>
-        fetch(`/proxy/empresas/${empresaId}/usuarios/${userId}`, {
+        fetch(`${window.API_BASE_URL}/empresas/${empresaId}/usuarios/${userId}`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(data)
         }),
       create_usuario: (empresaId, data) =>
-        fetch(`/proxy/empresas/${empresaId}/usuarios`, {
+        fetch(`${window.API_BASE_URL}/empresas/${empresaId}/usuarios`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(data)
         }),
       delete_usuario: (empresaId, userId) =>
-        fetch(`/proxy/empresas/${empresaId}/usuarios/${userId}`, {
+        fetch(`${window.API_BASE_URL}/empresas/${empresaId}/usuarios/${userId}`, {
           method: 'DELETE'
         })
     };

--- a/templates/admin/company_types.html
+++ b/templates/admin/company_types.html
@@ -1452,7 +1452,7 @@ async function callAPI(method, endpoint, data = null) {
   
   try {
     console.log(`🔄 API Call: ${method} ${endpoint}`);
-    const response = await fetch(`/proxy${endpoint}`, options);
+    const response = await fetch(`${API_BASE_URL}${endpoint}`, options);
     const result = await response.json();
     
     console.log(`📡 API Response: ${response.status}`, result);

--- a/templates/admin/hardware.html
+++ b/templates/admin/hardware.html
@@ -1438,10 +1438,10 @@ function checkModalElements() {
 }
 
 // Get token from session and initialize
-fetch('/proxy/health')
+fetch(`${API_BASE_URL}/health`, { credentials: 'include' })
   .then(response => {
     if (response.ok) {
-      apiClient = new EndpointTestClient('/proxy');
+      apiClient = new EndpointTestClient(API_BASE_URL);
       console.log('API Client initialized');
       
       // Check modal elements
@@ -1479,10 +1479,10 @@ async function loadHardware() {
     
     let response;
     if (includeInactive) {
-      console.log('🌐 Haciendo petición a:', '/proxy/api/hardware/all-including-inactive');
+      console.log('🌐 Haciendo petición a:', `${API_BASE_URL}/api/hardware/all-including-inactive`);
       response = await apiClient.get_hardware_list_including_inactive();
     } else {
-      console.log('🌐 Haciendo petición a:', '/proxy/api/hardware');
+      console.log('🌐 Haciendo petición a:', `${API_BASE_URL}/api/hardware`);
       response = await apiClient.get_hardware_list();
     }
     
@@ -1980,7 +1980,7 @@ async function loadHardwareTypes() {
 // Load empresas from backend
 async function loadEmpresas() {
   try {
-    console.log('🏢 Cargando empresas desde /proxy/api/empresas...');
+    console.log('🏢 Cargando empresas desde ' + `${API_BASE_URL}/api/empresas` + '...');
     const response = await apiClient.get_empresas();
     const data = await response.json();
     


### PR DESCRIPTION
## Summary
- switch Python API client to use session cookies
- store backend cookies in Flask session on login
- update dashboards and views to rely on cookies instead of tokens
- switch JS and templates to use backend URL instead of proxy

## Testing
- `python -m py_compile app.py python_api_client.py dashboard_data_providers.py`

------
https://chatgpt.com/codex/tasks/task_e_687076f856ec8332b0182be2ac864301