### PR TITLE
Switch backend client to cookie auth

### DIFF
--- a/app.py
+++ b/app.py
@@ -109,8 +109,8 @@ def attach_api_client():
             session.clear()
             return redirect(url_for('login', error='backend_unavailable'))
     
-    token = session.get('token')
-    g.api_client = EndpointTestClient(BACKEND_API_URL, token)
+    # Forward authentication cookies to the backend
+    g.api_client = EndpointTestClient(BACKEND_API_URL, cookies=request.cookies)
 
 # ========== RUTAS PÚBLICAS ==========
 @app.route('/')
@@ -139,7 +139,7 @@ def login():
         res = client.login(usuario, password)
         if res.ok:
             data = res.json()
-            session['token'] = data.get('token')
+            session['token'] = 'jwt_cookie_auth'
             session['user'] = data.get('user')
             # NO hacer la sesión permanente - será temporal por defecto
             session.permanent = False
@@ -265,9 +265,9 @@ def super_admin_dashboard():
     try:
         from dashboard_data_providers import RealDashboardDataProvider
         from config import BACKEND_API_URL
-        
-        # Use real data provider with session token
-        real_provider = RealDashboardDataProvider(BACKEND_API_URL, session.get('token'))
+
+        # Use real data provider with authentication cookies
+        real_provider = RealDashboardDataProvider(BACKEND_API_URL, request.cookies)
         dashboard_data = real_provider.get_dashboard_data()
         
         # Add hardware stats if not already present

--- a/dashboard_data_providers.py
+++ b/dashboard_data_providers.py
@@ -9,7 +9,7 @@ import random
 from datetime import datetime, timedelta
 from typing import List, Dict, Any
 from python_api_client import EndpointTestClient
-from flask import session
+from flask import session, request
 import logging
 
 logger = logging.getLogger(__name__)
@@ -18,9 +18,10 @@ logger = logging.getLogger(__name__)
 class RealDashboardDataProvider:
     """Provides dashboard data from real API endpoints"""
     
-    def __init__(self, api_base_url: str, token: str = None):
+    def __init__(self, api_base_url: str, cookies: Dict[str, str] = None):
+        """Initialize the provider using cookie based authentication."""
         self.api_base_url = api_base_url
-        self.client = EndpointTestClient(api_base_url, token)
+        self.client = EndpointTestClient(api_base_url, cookies=cookies)
         self.dummy_provider = DashboardDataProvider()  # Fallback to dummy data
     
     def get_dashboard_data(self) -> Dict[str, Any]:
@@ -500,7 +501,7 @@ def get_dashboard_stats():
     try:
         if 'token' in session:
             from config import BACKEND_API_URL
-            real_provider = RealDashboardDataProvider(BACKEND_API_URL, session['token'])
+            real_provider = RealDashboardDataProvider(BACKEND_API_URL, request.cookies)
             return real_provider.get_dashboard_data()
     except Exception as e:
         logger.warning(f"Could not get real dashboard data: {e}")
@@ -515,7 +516,7 @@ def get_companies_stats():
     try:
         if 'token' in session:
             from config import BACKEND_API_URL
-            real_provider = RealDashboardDataProvider(BACKEND_API_URL, session['token'])
+            real_provider = RealDashboardDataProvider(BACKEND_API_URL, request.cookies)
             companies_response = real_provider.client.get_dashboard_recent_companies()
             if companies_response.ok:
                 return {
@@ -535,7 +536,7 @@ def get_detailed_statistics():
     try:
         if 'token' in session:
             from config import BACKEND_API_URL
-            real_provider = RealDashboardDataProvider(BACKEND_API_URL, session['token'])
+            real_provider = RealDashboardDataProvider(BACKEND_API_URL, request.cookies)
             performance_data = real_provider.get_system_performance()
             if performance_data:
                 return {
@@ -560,7 +561,7 @@ def get_hardware_data():
     try:
         if 'token' in session:
             from config import BACKEND_API_URL
-            real_provider = RealDashboardDataProvider(BACKEND_API_URL, session['token'])
+            real_provider = RealDashboardDataProvider(BACKEND_API_URL, request.cookies)
             hardware_stats = real_provider.get_hardware_stats()
             if hardware_stats:
                 return {

--- a/python_api_client.py
+++ b/python_api_client.py
@@ -64,7 +64,15 @@ class EndpointTestClient:
     # Authentication and health endpoints
     # ------------------------------------------------------------------
     def login(self, usuario: str, password: str) -> requests.Response:
-        return self._request("POST", "/auth/login", data={"usuario": usuario, "password": password})
+        response = self._request(
+            "POST",
+            "/auth/login",
+            data={"usuario": usuario, "password": password},
+        )
+        # Store cookies returned by the backend
+        if response.cookies:
+            self.cookies.update(response.cookies.get_dict())
+        return response
 
     def health(self) -> requests.Response:
         return self._request("GET", "/health")

--- a/static/js/auth-manager.js
+++ b/static/js/auth-manager.js
@@ -76,14 +76,15 @@ class AuthManager {
             
             const result = await response.json();
             console.log('📝 Datos de respuesta:', result);
-            
+
             if (response.ok && result.success) {
                 console.log('✅ Login exitoso - cookie establecida automáticamente por el browser');
-                
+
+                const userInfo = result.user || result.data;
                 // Sincronizar sesión con Flask
-                const syncSuccess = await this.syncSession(result.user);
+                const syncSuccess = await this.syncSession(userInfo);
                 if (syncSuccess) {
-                    return { success: true, user: result.user };
+                    return { success: true, user: userInfo };
                 } else {
                     return { success: false, errors: ['Error sincronizando sesión'] };
                 }


### PR DESCRIPTION
## Summary
- forward request cookies when proxying to the backend
- update dashboard data provider to use cookies
- support cookies in `EndpointTestClient`

## Testing
- `python -m py_compile app.py dashboard_data_providers.py python_api_client.py`

------
https://chatgpt.com/codex/tasks/task_e_687076f856ec8332b0182be2ac864301