### PR TITLE
fix: disable gsap on dashboards to keep scroll stable

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -431,8 +431,10 @@
     <!-- GSAP Configuration (Global) -->
     <script src="{{ url_for('static', filename='js/gsap-config.js') }}?v={{ cache_version if cache_version else '1.0' }}"></script>
     
-    <!-- GSAP Main Controller -->
+    <!-- GSAP Main Controller (skip on admin/empresa dashboards to prevent scroll flicker) -->
+    {% if not (current_route.startswith('admin') or current_route.startswith('empresa') or current_route.startswith('super_admin')) %}
     <script type="module" src="{{ url_for('static', filename='js/gsap_main.js') }}?v={{ cache_version if cache_version else '1.0' }}"></script>
+    {% endif %}
 
     <!-- Utils -->
     <script src="{{ url_for('static', filename='js/api-client.js') }}"></script>


### PR DESCRIPTION
## Summary
- evitar que el controlador principal de GSAP se cargue en vistas de administrador y empresa para prevenir el parpadeo del scroll

## Testing
- `npm test` *(falló: Missing script: "test")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a823a679a4833295c6fdce271fd1bb