### PR TITLE
Fix auto-open of inactive alerts modal

### DIFF
--- a/static/js/alerts/alerts-inactive-main.js
+++ b/static/js/alerts/alerts-inactive-main.js
@@ -180,7 +180,7 @@ function renderInactiveAlerts(alerts) {
         }
         
         return `
-        <div class="alert-card ios-hardware-card alert-priority-${alert.prioridad} alert-status-inactive" onclick="//console.log('🖱️ CLICK en alerta:', '${alert._id}'); window.showInactiveAlertDetails('${alert._id}');">
+        <div class="alert-card ios-hardware-card alert-priority-${alert.prioridad} alert-status-inactive" onclick="window.showInactiveAlertDetails('${alert._id}');">
             <div class="flex items-start space-x-4">
                 <div class="flex-shrink-0">
                     <div class="w-16 h-16 rounded-xl flex items-center justify-center ${

--- a/static/js/alerts/alerts-inactive-main.js
+++ b/static/js/alerts/alerts-inactive-main.js
@@ -1239,6 +1239,33 @@ function generateEmbeddedMap(googleUrl, osmUrl) {
     return '<p class="text-gray-400 text-xs mb-4">⚠️ No se pudieron extraer coordenadas de los enlaces</p>';
 }
 
+
+// ========== FUNCIÓN PARA APERTURA AUTOMÁTICA DE MODAL ==========
+/**
+ * Verifica si debe abrir automáticamente el modal de una alerta inactiva
+ * Esto se activa cuando se llega desde el sistema global de alertas
+ */
+function checkForAutoOpenInactiveAlert() {
+    // Obtener ID de alerta almacenado para apertura automática
+    const openAlertId = sessionStorage.getItem("openAlertId");
+
+    if (openAlertId) {
+        // Limpiar la variable de sesión para evitar reaperturas
+        sessionStorage.removeItem("openAlertId");
+
+        // Esperar a que las alertas se carguen antes de abrir
+        setTimeout(async () => {
+            const alert = await findInactiveAlertById(openAlertId);
+            if (alert) {
+                showInactiveAlertDetails(openAlertId);
+            } else if (typeof window.showSimpleNotification === "function") {
+                // Notificar si la alerta no se pudo cargar
+                window.showSimpleNotification("La alerta seleccionada no se pudo cargar", "warning");
+            }
+        }, 1500);
+    }
+}
+
 // Hacer funciones disponibles globalmente
 window.showInactiveAlertDetails = showInactiveAlertDetails;
 window.closeAlertModal = closeAlertModal;

--- a/static/js/alerts/alerts-inactive-main.js
+++ b/static/js/alerts/alerts-inactive-main.js
@@ -39,7 +39,9 @@ document.addEventListener('DOMContentLoaded', function() {
     
     // Verificar si debe abrir automáticamente una alerta específica
     setTimeout(() => {
-        checkForAutoOpenInactiveAlert();
+        if (typeof window.checkForAutoOpenInactiveAlert === 'function') {
+            window.checkForAutoOpenInactiveAlert();
+        }
     }, 1500);
     
     //console.log('✅ ALERTAS INACTIVAS: Sistema completamente inicializado');
@@ -1271,3 +1273,4 @@ window.showInactiveAlertDetails = showInactiveAlertDetails;
 window.closeAlertModal = closeAlertModal;
 window.showDeactivateConfirmation = showDeactivateConfirmation;
 window.changePageInactive = changePageInactive;
+window.checkForAutoOpenInactiveAlert = checkForAutoOpenInactiveAlert;


### PR DESCRIPTION
## Summary
- add missing `checkForAutoOpenInactiveAlert` to enable auto-opening of inactive alerts modal

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a82a8fba6c8332addacd280b08ccc3