### PR TITLE
Fix admin user modal styling and toggle messages

### DIFF
--- a/static/js/usuarios/usuarios-modals.js
+++ b/static/js/usuarios/usuarios-modals.js
@@ -968,8 +968,9 @@ class UsuariosModals {
         
         if (isSuccess) {
           this.closeToggleModal();
-          this.showSuccessModal(data.message || `Usuario ${newStatus ? 'activado' : 'desactivado'} exitosamente`);
-          
+          const updatedStatus = data.usuario?.activo ?? data.user?.activo ?? newStatus;
+          this.showSuccessModal(`Usuario ${updatedStatus ? 'activado' : 'desactivado'} exitosamente`);
+
           if (window.usuariosMain && window.usuariosMain.refreshUsers) {
             setTimeout(() => {
               window.usuariosMain.refreshUsers();

--- a/templates/admin/users.html
+++ b/templates/admin/users.html
@@ -5,6 +5,10 @@
 {% block extra_css %}
 {{ super() }}
 <!-- Los scripts globales ya se cargan en dashboard.html -->
+<link href="{{ url_for('static', filename='css/modals.css') }}" rel="stylesheet">
+<link href="{{ url_for('static', filename='css/hardware/hardware-main.css') }}" rel="stylesheet">
+<link href="{{ url_for('static', filename='css/usuarios/usuarios-modal-fix.css') }}" rel="stylesheet">
+<link href="{{ url_for('static', filename='css/usuarios/usuarios-main.css') }}" rel="stylesheet">
 {% endblock %}
 
 {% block main_content %}


### PR DESCRIPTION
## Summary
- load usuarios modal CSS in admin user view to use correct styles
- ensure toggle user action displays proper activated/deactivated message

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aa357610108332a8456a88e119a3f5