### PR TITLE
Centralize date helpers and normalize timestamps

### DIFF
--- a/app.py
+++ b/app.py
@@ -925,7 +925,7 @@ def empresa_stats():
                             },
                             'actividad_reciente': {
                                 'logs_ultimos_30_dias': backend_data.get('alertas', {}).get('alertas_recientes_30d', 0),
-                                'ultima_actividad': backend_data.get('empresa', {}).get('fecha_creacion', '2024-07-20T10:30:00Z')
+                                'ultima_actividad': backend_data.get('empresa', {}).get('ultima_actividad', '2024-07-20T10:30:00Z')
                             }
                         }
                         print(f"✅ Loaded and mapped empresa statistics")
@@ -1109,7 +1109,7 @@ def date_format_filter(value, format='%d/%m/%Y'):
                 return value.strftime(format)
             else:
                 from datetime import datetime
-                return datetime.fromisoformat(str(value)).strftime(format)
+                return datetime.fromisoformat(str(value).replace('Z', '+00:00')).strftime(format)
         except (AttributeError, ValueError, TypeError):
             return str(value)
     return ''

--- a/static/js/alerts/alerts-create.js
+++ b/static/js/alerts/alerts-create.js
@@ -197,13 +197,7 @@ function updateAlertDateTime() {
     const alertFechaInfo = document.getElementById('alertFechaInfo');
     if (alertFechaInfo) {
         const now = new Date();
-        alertFechaInfo.textContent = now.toLocaleString('es-CO', {
-            year: 'numeric',
-            month: 'long',
-            day: 'numeric',
-            hour: '2-digit',
-            minute: '2-digit'
-        });
+        alertFechaInfo.textContent = formatDateTimeForUser(now.toISOString());
     }
 }
 

--- a/static/js/alerts/alerts-inactive-main.js
+++ b/static/js/alerts/alerts-inactive-main.js
@@ -234,14 +234,14 @@ function renderInactiveAlerts(alerts) {
                     ${alert.fecha_desactivacion ? `
                         <div class="mt-2 text-xs text-red-300">
                             <i class="fas fa-power-off mr-1"></i>
-                            Desactivada: ${formatDate(alert.fecha_desactivacion)}
+                            Desactivada: ${getTimeAgo(alert.fecha_desactivacion)}
                         </div>
                     ` : ''}
                     
                     <div class="mt-3 flex items-center justify-between">
                         <span class="alert-timestamp text-gray-400">
                             <i class="fas fa-clock mr-1"></i>
-                            Creada: ${formatDate(alert.fecha_creacion)}
+                            Creada: ${getTimeAgo(alert.fecha_creacion)}
                         </span>
                         
                         <div class="flex items-center space-x-2 text-xs">
@@ -577,9 +577,9 @@ function generateInactiveModalContent(alert, isUserOrigin, isHardwareOrigin, isE
                 <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                     <div class="bg-black/20 rounded-lg p-3">
                         <span class="text-red-200 text-sm block mb-1">Fecha de Desactivación:</span>
-                        <span class="text-white font-medium">${alert.fecha_desactivacion ? formatDate(alert.fecha_desactivacion) : 'No disponible'}</span>
+                        <span class="text-white font-medium">${alert.fecha_desactivacion ? formatDateTimeForUser(alert.fecha_desactivacion) : 'No disponible'}</span>
                         ${alert.desactivado_por?.fecha_desactivacion ? `
-                            <p class="text-red-300 text-xs mt-1 font-mono">${new Date(alert.desactivado_por.fecha_desactivacion).toLocaleString()}</p>
+                            <p class="text-red-300 text-xs mt-1 font-mono">${formatDateTimeForUser(alert.desactivado_por.fecha_desactivacion)}</p>
                         ` : ''}
                     </div>
                     <div class="bg-black/20 rounded-lg p-3">
@@ -620,7 +620,7 @@ function generateInactiveModalContent(alert, isUserOrigin, isHardwareOrigin, isE
                         <div class="mt-2">
                             <span class="inline-flex items-center px-2 py-1 bg-red-600/30 text-red-200 text-xs rounded-full">
                                 <i class="fas fa-clock mr-1"></i>
-                                Desactivada ${alert.fecha_desactivacion ? formatDate(alert.fecha_desactivacion) : ''}
+                                Desactivada ${alert.fecha_desactivacion ? getTimeAgo(alert.fecha_desactivacion) : ''}
                             </span>
                         </div>
                     </div>
@@ -637,7 +637,7 @@ function generateInactiveModalContent(alert, isUserOrigin, isHardwareOrigin, isE
                                 <h5 class="text-red-200 font-medium text-sm mb-1">Detalles de Desactivación</h5>
                                 <p class="text-red-300 text-xs leading-relaxed">
                                     Esta alerta fue desactivada por <strong>${alert.desactivado_por.tipo === 'empresa' ? 'la empresa' : alert.desactivado_por.tipo === 'usuario' ? 'un usuario' : 'el sistema'}</strong>
-                                    ${alert.fecha_desactivacion ? ` el ${new Date(alert.fecha_desactivacion).toLocaleDateString()} a las ${new Date(alert.fecha_desactivacion).toLocaleTimeString()}` : ''}.
+                                    ${alert.fecha_desactivacion ? ` el ${formatDateTimeForUser(alert.fecha_desactivacion)}` : ''}.
                                     ${alert.desactivado_por.tipo === 'empresa' ? ' La desactivación fue realizada desde el panel de administración de la empresa.' : 
                                       alert.desactivado_por.tipo === 'usuario' ? ' Un usuario autorizado desactivó manualmente esta alerta.' : 
                                       ' La alerta fue desactivada automáticamente por el sistema.'}
@@ -1046,20 +1046,6 @@ if (typeof getAlertTypeColor === 'undefined') {
     }
 }
 
-if (typeof formatDate === 'undefined') {
-    function formatDate(dateString) {
-        const date = new Date(dateString);
-        const now = new Date();
-        const diff = now - date;
-        const minutes = Math.floor(diff / 60000);
-        const hours = Math.floor(diff / 3600000);
-        const days = Math.floor(diff / 86400000);
-        
-        if (minutes < 60) return `Hace ${minutes} minutos`;
-        if (hours < 24) return `Hace ${hours} horas`;
-        return `Hace ${days} días`;
-    }
-}
 
 // ========== FUNCIONES GLOBALES DE MODAL ==========
 function closeAlertModal() {
@@ -1188,7 +1174,7 @@ function generateOriginDetailsContent(alert, isUserOrigin, isHardwareOrigin, isE
                         <div class="bg-black/20 rounded p-2">
                             <div class="flex justify-between">
                                 <span class="text-purple-200">Timestamp:</span>
-                                <span class="text-white font-mono text-xs">${new Date(alert.data.timestamp_creacion).toLocaleString()}</span>
+                                <span class="text-white font-mono text-xs">${formatDateTimeForUser(alert.data.timestamp_creacion)}</span>
                             </div>
                         </div>
                     ` : ''}
@@ -1276,7 +1262,7 @@ function generateOriginDetailsContent(alert, isUserOrigin, isHardwareOrigin, isE
                         <div class="bg-black/20 rounded p-2">
                             <div class="flex justify-between">
                                 <span class="text-amber-200">Timestamp:</span>
-                                <span class="text-white font-mono text-xs">${new Date(alert.data.timestamp_creacion).toLocaleString()}</span>
+                                <span class="text-white font-mono text-xs">${formatDateTimeForUser(alert.data.timestamp_creacion)}</span>
                             </div>
                         </div>
                     ` : ''}

--- a/static/js/alerts/alerts-inactive-main.js
+++ b/static/js/alerts/alerts-inactive-main.js
@@ -714,6 +714,12 @@ function generateInactiveModalContent(alert, isUserOrigin, isHardwareOrigin, isE
                             ${alert.prioridad.toUpperCase()}
                         </span>
                     </div>
+                    <div class="flex justify-between">
+                        <span class="text-gray-400">Creada:</span>
+                        <span class="text-white">${formatDateTimeForUser(alert.fecha_creacion)}
+                            <span class="block text-gray-500 text-xs">${getTimeAgo(alert.fecha_creacion)}</span>
+                        </span>
+                    </div>
                 </div>
             </div>
 

--- a/static/js/alerts/alerts-inactive-main.js
+++ b/static/js/alerts/alerts-inactive-main.js
@@ -481,6 +481,8 @@ async function showInactiveAlertDetails(alertId) {
 
     //console.log('✅ Alerta inactiva encontrada:', alert);
     selectedInactiveAlertId = alertId;
+
+    console.log('[alerts-inactive] Opening alert modal. Locale:', window.detectedUserLocale, 'Timezone:', window.detectedUserZone, 'ISO:', alert.fecha_desactivacion || alert.fecha_creacion);
     
     const modal = document.getElementById('alertDetailModal');
     if (!modal) {

--- a/static/js/alerts/alerts-main.js
+++ b/static/js/alerts/alerts-main.js
@@ -767,7 +767,8 @@ function generateModalContent(alert, isUserOrigin, isHardwareOrigin) {
                             <div class="mt-2 pt-2 border-t border-gray-600">
                                 <p class="text-xs text-gray-400 mb-1">
                                     <i class="fas fa-calendar-times mr-1"></i>
-                                    Desactivada: ${getTimeAgo(alert.fecha_desactivacion)}
+                                    Desactivada: ${formatDateTimeForUser(alert.fecha_desactivacion)}
+                                    <span class="block">${getTimeAgo(alert.fecha_desactivacion)}</span>
                                 </p>
                                 ${alert.desactivado_por ? `
                                     <p class="text-xs text-gray-400">

--- a/static/js/alerts/alerts-main.js
+++ b/static/js/alerts/alerts-main.js
@@ -418,7 +418,7 @@ function renderAlerts(alerts) {
                     <div class="mt-3 flex items-center justify-between">
                         <span class="alert-timestamp text-gray-400">
                             <i class="fas fa-clock mr-1"></i>
-                            ${formatDate(alert.fecha_creacion)}
+                            ${getTimeAgo(alert.fecha_creacion)}
                         </span>
                         
                         <div class="flex items-center space-x-2 text-xs">
@@ -490,18 +490,6 @@ function getAlertTypeColor(tipo) {
     }
 }
 
-function formatDate(dateString) {
-    const date = new Date(dateString);
-    const now = new Date();
-    const diff = now - date;
-    const minutes = Math.floor(diff / 60000);
-    const hours = Math.floor(diff / 3600000);
-    const days = Math.floor(diff / 86400000);
-    
-    if (minutes < 60) return `Hace ${minutes} minutos`;
-    if (hours < 24) return `Hace ${hours} horas`;
-    return `Hace ${days} días`;
-}
 
 // ========== FUNCIONES DE MODAL ==========
 async function showAlertDetails(alertId) {
@@ -679,7 +667,7 @@ function generateModalContent(alert, isUserOrigin, isHardwareOrigin) {
                             ${alert.prioridad.toUpperCase()}
                         </span>
                         <span class="px-2 py-1 rounded-full text-xs font-bold bg-indigo-500/30 text-indigo-200">
-                            ${formatDate(alert.fecha_creacion)}
+                            ${getTimeAgo(alert.fecha_creacion)}
                         </span>
                     </div>
                 </div>
@@ -777,7 +765,7 @@ function generateModalContent(alert, isUserOrigin, isHardwareOrigin) {
                             <div class="mt-2 pt-2 border-t border-gray-600">
                                 <p class="text-xs text-gray-400 mb-1">
                                     <i class="fas fa-calendar-times mr-1"></i>
-                                    Desactivada: ${formatDate(alert.fecha_desactivacion)}
+                                    Desactivada: ${getTimeAgo(alert.fecha_desactivacion)}
                                 </p>
                                 ${alert.desactivado_por ? `
                                     <p class="text-xs text-gray-400">
@@ -2007,7 +1995,7 @@ function generateOriginDetailsContent(alert, isUserOrigin, isHardwareOrigin) {
                         <div class="bg-black/20 rounded p-2">
                             <div class="flex justify-between">
                                 <span class="text-purple-200">Timestamp:</span>
-                                <span class="text-white font-mono text-xs">${new Date(alert.data.timestamp_creacion).toLocaleString()}</span>
+                                <span class="text-white font-mono text-xs">${formatDateTimeForUser(alert.data.timestamp_creacion)}</span>
                             </div>
                         </div>
                     ` : ''}
@@ -2107,7 +2095,7 @@ function generateOriginDetailsContent(alert, isUserOrigin, isHardwareOrigin) {
                         <div class="bg-black/20 rounded p-2">
                             <div class="flex justify-between">
                                 <span class="text-teal-200">Creada:</span>
-                                <span class="text-white font-mono text-xs">${new Date(alert.data?.timestamp_creacion || alert.fecha_creacion).toLocaleString()}</span>
+                                <span class="text-white font-mono text-xs">${formatDateTimeForUser(alert.data?.timestamp_creacion || alert.fecha_creacion)}</span>
                             </div>
                         </div>
                     ` : ''}
@@ -2687,7 +2675,6 @@ function checkForAutoOpenAlert() {
 window.generateModalContent = generateModalContent;
 window.getPriorityClass = getPriorityClass;
 window.getAlertTypeColor = getAlertTypeColor;
-window.formatDate = formatDate;
 window.generateLocationContent = generateLocationContent;
 window.generateEmbeddedMap = generateEmbeddedMap;
 window.generateSpecificLocationContent = generateSpecificLocationContent;

--- a/static/js/alerts/alerts-main.js
+++ b/static/js/alerts/alerts-main.js
@@ -504,6 +504,8 @@ async function showAlertDetails(alertId) {
     
     //console.log('✅ Alerta encontrada:', alert);
     selectedAlertId = alertId;
+
+    console.log('[alerts-main] Opening alert modal. Locale:', window.detectedUserLocale, 'Timezone:', window.detectedUserZone, 'ISO:', alert.fecha_creacion);
     
     const modal = document.getElementById('alertDetailModal');
     if (!modal) {

--- a/static/js/empresa/empresa-alerts-global.js
+++ b/static/js/empresa/empresa-alerts-global.js
@@ -564,7 +564,7 @@ class EmpresaAlertsGlobal {
         }
         
         const alertsHTML = alerts.map(alert => {
-            const timeAgo = this.getTimeAgo(alert.fecha_creacion);
+            const timeAgo = getTimeAgo(alert.fecha_creacion);
             const priorityClass = alert.prioridad || 'media';
             
             return `
@@ -585,19 +585,6 @@ class EmpresaAlertsGlobal {
         }).join('');
         
         panel.innerHTML = alertsHTML;
-    }
-    
-    getTimeAgo(dateString) {
-        const date = new Date(dateString);
-        const now = new Date();
-        const diff = now - date;
-        const minutes = Math.floor(diff / 60000);
-        const hours = Math.floor(diff / 3600000);
-        const days = Math.floor(diff / 86400000);
-        
-        if (minutes < 60) return `Hace ${minutes} min`;
-        if (hours < 24) return `Hace ${hours} horas`;
-        return `Hace ${days} días`;
     }
     
     showError() {
@@ -902,7 +889,7 @@ class EmpresaAlertsGlobal {
                                 <div class="flex items-center justify-between">
                                     <div class="flex items-center text-white/90">
                                         <i class="fas fa-clock w-5 text-white/70"></i>
-                                        <span>${this.getTimeAgo(alert.fecha_creacion)}</span>
+                                        <span>${getTimeAgo(alert.fecha_creacion)}</span>
                                     </div>
                                     
                                     <span class="px-2 py-1 rounded-full text-xs font-bold ${

--- a/static/js/utils/date-utils.js
+++ b/static/js/utils/date-utils.js
@@ -1,0 +1,21 @@
+(function() {
+  function getTimeAgo(dateString) {
+    if (!dateString) return '';
+    const date = new Date(dateString);
+    if (isNaN(date)) return '';
+    const now = new Date();
+    let diff = now - date;
+    if (diff < 0) diff = 0;
+    const seconds = Math.floor(diff / 1000);
+    const minutes = Math.floor(seconds / 60);
+    const hours = Math.floor(minutes / 60);
+    const days = Math.floor(hours / 24);
+
+    if (days > 0) return `Hace ${days} día${days !== 1 ? 's' : ''}`;
+    if (hours > 0) return `Hace ${hours} hora${hours !== 1 ? 's' : ''}`;
+    if (minutes > 0) return `Hace ${minutes} minuto${minutes !== 1 ? 's' : ''}`;
+    return `Hace ${seconds} segundo${seconds !== 1 ? 's' : ''}`;
+  }
+
+  window.getTimeAgo = getTimeAgo;
+})();

--- a/static/js/utils/date-utils.js
+++ b/static/js/utils/date-utils.js
@@ -1,8 +1,24 @@
 (function() {
+  function parseISODate(isoString) {
+    if (typeof window !== 'undefined' && window.parseISODate) {
+      return window.parseISODate(isoString);
+    }
+    if (!isoString) return null;
+    try {
+      let normalized = String(isoString);
+      if (!/(Z|[+-]\d{2}:?\d{2})$/.test(normalized)) {
+        normalized += 'Z';
+      }
+      const date = new Date(normalized);
+      return isNaN(date) ? null : date;
+    } catch (e) {
+      return null;
+    }
+  }
+
   function getTimeAgo(dateString) {
-    if (!dateString) return '';
-    const date = new Date(dateString);
-    if (isNaN(date)) return '';
+    const date = parseISODate(dateString);
+    if (!date) return '';
     const now = new Date();
     let diff = now - date;
     if (diff < 0) diff = 0;

--- a/static/js/utils/locale-time.js
+++ b/static/js/utils/locale-time.js
@@ -6,16 +6,33 @@
   window.detectedUserLocale = userLocale;
   window.detectedUserZone = userZone;
 
-  function formatDateTimeForUser(isoString, options = { dateStyle: 'short', timeStyle: 'short' }) {
-    if (!isoString) return '';
+  function parseISODate(isoString) {
+    if (!isoString) return null;
     try {
-      const date = new Date(isoString);
-      if (isNaN(date)) return '';
-      return new Intl.DateTimeFormat(userLocale, { ...options, timeZone: userZone }).format(date);
+      let normalized = String(isoString);
+      if (!/(Z|[+-]\d{2}:?\d{2})$/.test(normalized)) {
+        normalized += 'Z';
+      }
+      const date = new Date(normalized);
+      return isNaN(date) ? null : date;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function formatDateTimeForUser(isoString, options = { dateStyle: 'short', timeStyle: 'short' }) {
+    const date = parseISODate(isoString);
+    if (!date) return '';
+    try {
+      if (userZone && userZone !== 'UTC') {
+        return new Intl.DateTimeFormat(userLocale, { ...options, timeZone: userZone }).format(date);
+      }
+      return date.toLocaleString(userLocale, options);
     } catch (e) {
       return '';
     }
   }
 
   window.formatDateTimeForUser = formatDateTimeForUser;
+  window.parseISODate = parseISODate;
 })();

--- a/static/js/utils/locale-time.js
+++ b/static/js/utils/locale-time.js
@@ -2,6 +2,10 @@
   const userLocale = navigator.language || 'es-ES';
   const userZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
+  console.log('[locale-time] Browser locale:', userLocale, 'timezone:', userZone);
+  window.detectedUserLocale = userLocale;
+  window.detectedUserZone = userZone;
+
   function formatDateTimeForUser(isoString, options = { dateStyle: 'short', timeStyle: 'short' }) {
     if (!isoString) return '';
     try {

--- a/static/js/utils/locale-time.js
+++ b/static/js/utils/locale-time.js
@@ -1,0 +1,17 @@
+(function() {
+  const userLocale = navigator.language || 'es-ES';
+  const userZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+  function formatDateTimeForUser(isoString, options = { dateStyle: 'short', timeStyle: 'short' }) {
+    if (!isoString) return '';
+    try {
+      const date = new Date(isoString);
+      if (isNaN(date)) return '';
+      return new Intl.DateTimeFormat(userLocale, { ...options, timeZone: userZone }).format(date);
+    } catch (e) {
+      return '';
+    }
+  }
+
+  window.formatDateTimeForUser = formatDateTimeForUser;
+})();

--- a/templates/admin/hardware.html
+++ b/templates/admin/hardware.html
@@ -1531,20 +1531,8 @@ function showHardwareDetails(hardware) {
     
     if (fechaRaw && fechaRaw !== 'N/A') {
       try {
-        const fecha = new Date(fechaRaw);
-        if (!isNaN(fecha.getTime())) {
-          fechaCreacion = fecha.toLocaleDateString('es-ES', {
-            year: 'numeric',
-            month: 'long',
-            day: 'numeric',
-            hour: '2-digit',
-            minute: '2-digit'
-          });
-        } else {
-          fechaCreacion = fechaRaw; // Usar valor original si no se puede parsear
-        }
+        fechaCreacion = formatDateTimeForUser(fechaRaw);
       } catch (e) {
-        //console.warn('Error parsing date:', e);
         fechaCreacion = fechaRaw; // Usar valor original en caso de error
       }
     }

--- a/templates/base.html
+++ b/templates/base.html
@@ -803,8 +803,10 @@
     
 })();
     </script>
-    
-    
+
+    <script src="{{ url_for('static', filename='js/utils/locale-time.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/utils/date-utils.js') }}"></script>
+
     {% block extra_js %}{% endblock %}
-</body>
-</html>
+  </body>
+  </html>

--- a/templates/empresa/hardware.html
+++ b/templates/empresa/hardware.html
@@ -1495,20 +1495,8 @@ function showHardwareDetails(hardware) {
     
     if (fechaRaw && fechaRaw !== 'N/A') {
       try {
-        const fecha = new Date(fechaRaw);
-        if (!isNaN(fecha.getTime())) {
-          fechaCreacion = fecha.toLocaleDateString('es-ES', {
-            year: 'numeric',
-            month: 'long',
-            day: 'numeric',
-            hour: '2-digit',
-            minute: '2-digit'
-          });
-        } else {
-          fechaCreacion = fechaRaw; // Usar valor original si no se puede parsear
-        }
+        fechaCreacion = formatDateTimeForUser(fechaRaw);
       } catch (e) {
-        //console.warn('Error parsing date:', e);
         fechaCreacion = fechaRaw; // Usar valor original en caso de error
       }
     }

--- a/utils/api_client.py
+++ b/utils/api_client.py
@@ -9,6 +9,7 @@ más comunes al backend de forma consistente y reutilizable.
 import requests
 from typing import Dict, Any, Optional
 from flask import request
+from datetime import datetime
 
 
 class APIClient:
@@ -20,6 +21,14 @@ class APIClient:
     def _get_auth_cookies(self) -> Dict[str, str]:
         """Obtiene las cookies de autenticación de la petición actual"""
         return {'auth_token': request.cookies.get('auth_token')} if request.cookies.get('auth_token') else {}
+
+    def _normalize_date(self, value: Any) -> str:
+        if not value:
+            return ''
+        try:
+            return datetime.fromisoformat(str(value).replace('Z', '+00:00')).isoformat()
+        except (ValueError, TypeError):
+            return str(value)
     
     def _make_request(self, method: str, endpoint: str, **kwargs) -> requests.Response:
         """Hace una petición HTTP con autenticación automática"""
@@ -231,7 +240,7 @@ class APIClient:
                             'active': raw_type.get('activo', True),
                             'companies_count': raw_type.get('empresas_count', 0),
                             'features': raw_type.get('caracteristicas', []),
-                            'created_at': raw_type.get('fecha_creacion', ''),
+                            'created_at': self._normalize_date(raw_type.get('fecha_creacion')),
                             'color': '#8b5cf6',  # Default purple
                             'icon': 'fas fa-building'  # Default icon
                         }


### PR DESCRIPTION
## Summary
- add locale-aware `formatDateTimeForUser` and relative `getTimeAgo` helpers
- replace scattered date logic in alerts and hardware modules with shared utilities
- fix backend date parsing and mapping for ISO timestamps

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab651055548332b660735776c31af3