### PR TITLE
Normalize date formatting for active alerts

### DIFF
--- a/static/js/alerts/alerts-main.js
+++ b/static/js/alerts/alerts-main.js
@@ -270,8 +270,8 @@ function updateStatsCards(alerts, pagination) {
     const now = new Date();
     const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
     const recentCount = alerts.filter(a => {
-        const alertDate = new Date(a.fecha_creacion);
-        return alertDate >= oneDayAgo;
+        const alertDate = parseISODate(a.fecha_creacion);
+        return alertDate && alertDate >= oneDayAgo;
     }).length;
     
     document.getElementById('totalAlertsCount').textContent = totalAlerts;
@@ -668,8 +668,9 @@ function generateModalContent(alert, isUserOrigin, isHardwareOrigin) {
                         <span class="px-2 py-1 rounded-full text-xs font-bold ${getPriorityClass(alert.prioridad)}">
                             ${alert.prioridad.toUpperCase()}
                         </span>
-                        <span class="px-2 py-1 rounded-full text-xs font-bold bg-indigo-500/30 text-indigo-200">
-                            ${getTimeAgo(alert.fecha_creacion)}
+                        <span class="px-2 py-1 rounded-full text-xs font-bold bg-indigo-500/30 text-indigo-200 text-center">
+                            ${formatDateTimeForUser(alert.fecha_creacion)}
+                            <span class="block text-[10px] opacity-70">${getTimeAgo(alert.fecha_creacion)}</span>
                         </span>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- Show full creation timestamp in active alert modal along with relative time
- Use `parseISODate` when counting recent alerts for stats cards

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab7426b2b48332b47aebe37fad10f0