### PR TITLE
Remove scroll from active alert contacts grid

### DIFF
--- a/static/js/alerts/alerts-main.js
+++ b/static/js/alerts/alerts-main.js
@@ -1119,7 +1119,7 @@ function generateModalContent(alert, isUserOrigin, isHardwareOrigin) {
                 <h4 class="text-lg font-semibold text-white mb-3 flex items-center">
                     <i class="fas fa-phone mr-2"></i>Contactos Notificados (${alert.numeros_telefonicos.length})
                 </h4>
-                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3 max-h-48 overflow-y-auto custom-scrollbar">
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
                     ${alert.numeros_telefonicos.map(contacto => `
                         <div class="bg-black/20 rounded-lg p-3 flex items-center space-x-3 hover:bg-black/30 transition-colors modal-card">
                             <div class="w-8 h-8 ${contacto.disponible ? 'bg-teal-500' : 'bg-red-500'} rounded-full flex items-center justify-center flex-shrink-0">


### PR DESCRIPTION
## Summary
- Expand 'Contactos Notificados' grid in active alert modal by removing height limitation and scrollbar

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab77d5a08083328b43b04181bbbc6f