### PR TITLE
fix: show hero title without animations

### DIFF
--- a/static/css/gsap_css/hero.css
+++ b/static/css/gsap_css/hero.css
@@ -69,6 +69,7 @@
     }
 }
 
+
 /* Hero Title */
 .hero-title {
     line-height: 1.45; /* Aumentado agresivamente a 1.45 */
@@ -83,43 +84,12 @@
     -moz-osx-font-smoothing: grayscale;
 }
 
-.title-word {
-    display: inline-block;
-    /* Estados iniciales removidos - controlados por GSAP JavaScript */
-    overflow: visible; /* Permitir que las descendentes sean visibles */
-    padding-bottom: 0.6rem; /* Mucho más espacio individual */
-    margin-bottom: 6px; /* Más pixelitos para descendentes */
-    vertical-align: top; /* Alineación superior para evitar cortes */
-    letter-spacing: normal; /* Espaciado normal entre letras */
-}
-
-/* Contenedor del título con más espacio */
-.hero-title .block {
-    overflow: visible;
-    padding-bottom: 0.8rem; /* Mucho más padding */
-    margin-bottom: 8px; /* Más espacio para bloques */
-}
-
-/* Contenedor específico para palabras con descendentes */
-.hero-title span {
-    overflow: visible !important;
-    padding-bottom: 0.5rem;
-    margin-bottom: 4px;
-    display: inline-block;
-}
-
 /* Espaciado responsivo para el título */
 @media (max-width: 1024px) {
     .hero-title {
         line-height: 1.5; /* Más espacio en tablet */
         padding-bottom: 1.4rem;
         letter-spacing: -0.02em; /* Ligeramente más compacto en tablet */
-    }
-    
-    .title-word {
-        padding-bottom: 0.7rem;
-        margin-bottom: 8px;
-        letter-spacing: -0.02em;
     }
 }
 
@@ -129,12 +99,6 @@
         padding-bottom: 1.6rem;
         letter-spacing: -0.03em; /* Más compacto en móvil */
     }
-    
-    .title-word {
-        padding-bottom: 0.8rem;
-        margin-bottom: 10px;
-        letter-spacing: -0.03em;
-    }
 }
 
 @media (max-width: 640px) {
@@ -142,12 +106,6 @@
         line-height: 1.6; /* Máximo espacio en móviles pequeños */
         padding-bottom: 2rem;
         letter-spacing: -0.04em; /* Más compacto en móviles pequeños */
-    }
-    
-    .title-word {
-        padding-bottom: 1rem;
-        margin-bottom: 12px;
-        letter-spacing: -0.04em;
     }
 }
 
@@ -158,18 +116,11 @@
     background-clip: text;
 }
 
-
 /* Ajustes específicos para diferentes tamaños de pantalla */
 @media (max-width: 480px) {
     .hero-title {
         line-height: 1.3; /* Más compacto en móviles muy pequeños */
         letter-spacing: -0.05em; /* Más compacto */
-    }
-    
-    .title-word {
-        letter-spacing: -0.05em;
-        padding-bottom: 0.5rem; /* Reducir padding extra */
-        margin-bottom: 6px;
     }
 }
 

--- a/static/js/gsap_js/hero.js
+++ b/static/js/gsap_js/hero.js
@@ -66,10 +66,6 @@
             //console.log('🎭 HERO: Estableciendo estados iniciales');
             
             // Ocultar elementos que se van a animar INMEDIATAMENTE
-            gsap.set(['.title-word'], {
-                y: 30, // Reducido a 30px para coherencia con el espaciado aumentado
-                opacity: 0
-            });
             
             gsap.set(['.status-badge'], {
                 scale: 0,
@@ -204,17 +200,9 @@
             
             // NO resetear propiedades - usar los estados ya establecidos
             
-            // Animar títulos palabra por palabra
-            tl.to('.title-word', {
-                y: 0,
-                opacity: 1,
-                duration: 0.8,
-                stagger: 0.15,
-                ease: "power3.out"
-            })
             
             // Status badge
-            .to('.status-badge', {
+            tl.to('.status-badge', {
                 scale: 1,
                 opacity: 1,
                 duration: 0.6,

--- a/templates/GSAP_Templates/hero.html
+++ b/templates/GSAP_Templates/hero.html
@@ -48,15 +48,7 @@
                     
                     <!-- Main Title -->
                     <h1 class="hero-title text-3xl sm:text-4xl md:text-5xl lg:text-4xl xl:text-5xl font-extrabold mb-4 md:mb-6">
-                        <span class="block overflow-hidden">
-                            <span class="title-word">Respuesta Eficiente en</span>
-                        </span>
-                        <span class="block overflow-hidden">
-                            <span class="title-word gradient-text">Situaciones Críticas y</span>
-                        </span>
-                        <span class="block overflow-hidden">
-                            <span class="title-word">Urgencias Extremas</span>
-                        </span>
+                        Tecnología de punta al servicio de tu negocio
                     </h1>
                     
                     <!-- Description -->


### PR DESCRIPTION
## Summary
- replace animated hero title with static text so it displays on all devices
- remove GSAP timeline and CSS for old title animation

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae2c3b12708332b195161af115cf51